### PR TITLE
Add (embarrassingly missing) alt text for images

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Our suggestions for adding new speakers:
 
 Format ([example pull request](https://github.com/karlhorky/awesome-speakers/pull/35/files)):
 
-* An image (Twitter profile picture is best)
+* An image (Twitter profile picture is best) - remember to add the alt tag!
 * Line 1: Name of the speaker
 * Line 2: Topics they talk about, capitalized (future topics in parentheses)
 * Line 3: Contact link (Twitter preferred)

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Juho Vepsäläinen
 Topics: 3D graphics, Business, React, webpack, Writing  
 https://twitter.com/bebraw
 
-<img alt="Headshot of Manuel Matuzović" src="https://pbs.twimg.com/profile_images/707504523678523392/Uasvv2C4_400x400.jpg" height="70" align="left"" alt="Headshot of Manuel Matuzović" />
+<img src="https://pbs.twimg.com/profile_images/707504523678523392/Uasvv2C4_400x400.jpg" height="70" align="left"" alt="Headshot of Manuel Matuzović" />
 Manuel Matuzović  
 Topics: CSS, Accesibility  
 https://twitter.com/mmatuzo  

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please add to the list and help make the community better connected and richer.
 Ire Aderinokun  
 Topics: PWA, CSS, Standards  
 https://twitter.com/ireaderinokun   
- 
+
 # Asia
 
 ## India 🇮🇳
@@ -27,13 +27,11 @@ Topics: PWA, Polymer, Web Components, Web Performance, Build Tools
 https://twitter.com/ashrith_kulai  
 
 <img src="https://i.imgur.com/OXCWwy7.jpg" height="70px" width="auto" align="left" />
-
 Kumar Anirudha  
 Topics: Python, Node.js, Blockchain, Architecture, Cryptocurrency  
 https://twitter.com/kranirudha
 
 <img src="https://pbs.twimg.com/profile_images/895583823202668544/kFsLGKC3_400x400.jpg" height="70px" width="auto" align="left" />
-
 Siddharth Kshetrapal  
 Topics: CSS, Web Performance, React, CSS in JS, Node, Testing  
 https://twitter.com/siddharthkp
@@ -41,19 +39,16 @@ https://twitter.com/siddharthkp
 ### Mumbai
 
 <img src="https://pbs.twimg.com/profile_images/856209876732739585/rQcsMvCa_400x400.jpg" height="70px" width="auto" align="left" />
-
 Manjula Dube  
 Topics: JavaScript, React, PWA, Node, Testing  
 https://twitter.com/manjula_dube
 
 <img src="https://pbs.twimg.com/profile_images/890131426217259008/6LEkT3eS_400x400.jpg" height="70px" width="auto" align="left" />
-
 Neehar Venugopal  
 Topics: Code Splitting, Standards  
 https://twitter.com/neeharv
 
 <img src="https://pbs.twimg.com/profile_images/907656585752842250/PwI99gBG_400x400.jpg" height="70px" width="auto" align="left" />
-
 Sidhartha Chatterjee  
 Topics: React, PWA, Web Performance  
 https://twitter.com/chatsidhartha
@@ -61,7 +56,6 @@ https://twitter.com/chatsidhartha
 ### New Delhi
 
 <img src="https://pbs.twimg.com/profile_images/514383461583294464/bIXQJcyG_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Arun Michael Dsouza  
 Topics: webpack, React, ES6, Tooling, CSS  
 https://twitter.com/amdsouza92
@@ -71,7 +65,6 @@ https://twitter.com/amdsouza92
 ### Tyre
 
 <img src="https://pbs.twimg.com/profile_images/903537944320987136/wB28L8qd_400x400.jpg" height="70px" width="auto" align="left" />
-
 Sara Soueidan  
 Topics: Animations, CSS, SVG  
 https://twitter.com/sarasoueidan
@@ -81,19 +74,16 @@ https://twitter.com/sarasoueidan
 ### Singapore
 
 <img src="https://pbs.twimg.com/profile_images/535685345472286720/9gjiNZiF_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Aysha Anggraini  
 Topics: CSS, Animations  
 https://twitter.com/renettarenula
 
 <img src="https://pbs.twimg.com/profile_images/917359648524558336/Zu2sC6Jk_400x400.jpg" height="70px" width="auto" align="left" />
-
 Chen Hui Jing  
 Topics: CSS  
 https://twitter.com/hj_chen
 
 <img src="https://pbs.twimg.com/profile_images/791843247312154625/UsLdWIIj_400x400.jpg" height="70px" width="auto" align="left" />
-
 Zell Liew  
 Topics: CSS, JavaScript  
 https://twitter.com/zellwk
@@ -105,25 +95,21 @@ https://twitter.com/zellwk
 ### Melbourne
 
 <img src="https://pbs.twimg.com/profile_images/683874690293612545/kDStZOBp_400x400.png" height="70px" width="auto" align="left" />
-
 Glen Maddern  
 Topics: CSS, Styled Components, React, JavaScript  
 https://twitter.com/glenmaddern
 
 <img src="https://pbs.twimg.com/profile_images/898083700818169856/prj-so7C_400x400.jpg" height="70px" width="auto" align="left" />
-
 Karolina Szczur  
 Topics: CSS, HTML, Web, Inclusivity, Diversity  
 https://twitter.com/fox
 
 <img src="https://pbs.twimg.com/profile_images/754886061872979968/BzaOWhs1_400x400.jpg" height="70px" width="auto" align="left" />
-
 Mark Dalgleish  
 Topics: Design Systems, Web Design  
 https://twitter.com/markdalgleish
 
 <img src="https://pbs.twimg.com/profile_images/789522857936220160/6OIm0gj0_400x400.jpg" height="70px" width="auto" align="left" />
-
 Phil Nash  
 Topics: JavaScript, Web Development, Progressive Web Apps  
 https://twitter.com/philnash
@@ -135,7 +121,6 @@ https://twitter.com/philnash
 ### Linz
 
 <img src="https://pbs.twimg.com/profile_images/572642811029426177/GxgFcPtm_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Stefan Baumgartner  
 Topics: Web Ops, JavaScript, CSS, Tooling  
 https://twitter.com/ddprrt
@@ -143,7 +128,6 @@ https://twitter.com/ddprrt
 ### Salzburg
 
 <img src="https://pbs.twimg.com/profile_images/861132772366331905/4xts32Lq_400x400.jpg" height="70px" width="auto" align="left" />
-
 Lisi Linhart  
 Topics: CSS, Web Animations  
 https://twitter.com/lisi_linhart
@@ -151,43 +135,36 @@ https://twitter.com/lisi_linhart
 ### Vienna
 
 <img src="https://pbs.twimg.com/profile_images/1492139238/profile_pic.jpg_400x400.jpg" height="70px" width="auto" align="left" />
-
 Ali Sharif  
 Topics: Functional Programming, Agile, Product Development  
 https://twitter.com/sharifsbeat
 
 <img src="https://pbs.twimg.com/profile_images/678903331176214528/TQTdqGwD_400x400.jpg" height="70px" width="auto" align="left" />
-
 Andrey Okonetchnikov  
 Topics: CSS in JS, Linting, Tooling  
 https://twitter.com/okonetchnikov
 
 <img src="https://pbs.twimg.com/profile_images/831514456828026880/IeSbt2Nw_400x400.jpg" height="70px" width="auto" align="left" />
-
 Christoph Rumpel  
 Topics: PHP, Laravel, Chatbots  
 https://twitter.com/christophrumpel
 
 <img src="https://pbs.twimg.com/profile_images/708910026245738496/CUhZSMYO_400x400.jpg" height="70px" width="auto" align="left" />
-
 Eva Lettner  
 Topics: CSS, Web  
 https://twitter.com/eva_trostlos
 
 <img src="https://pbs.twimg.com/profile_images/687205014348103680/ZcIXYv4g_400x400.jpg" height="70px" width="auto" align="left" />
-
 Glenn Reyes  
 Topics: Code splitting, React  
 https://twitter.com/glnnrys
 
 <img src="https://pbs.twimg.com/profile_images/875719105839603712/_nJ_XRw1_400x400.jpg" height="70px" width="auto" align="left" />
-
 Jan Hruby  
 Topics: React, Redux, CSS in JS, (React Native, Serverless, GraphQL)  
 https://twitter.com/mrozilla  
 
 <img src="https://pbs.twimg.com/profile_images/883661923107180544/OpPpk-Ku_400x400.jpg" height="70px" width="auto" align="left" />
-
 Juho Vepsäläinen  
 Topics: 3D graphics, Business, React, webpack, Writing  
 https://twitter.com/bebraw
@@ -199,43 +176,36 @@ Topics: CSS, Accesibility
 https://twitter.com/mmatuzo  
 
 <img src="https://pbs.twimg.com/profile_images/827473632351879169/ZnoB7yTR_400x400.jpg" height="70px" width="auto" align="left" />
-
 Max Böck  
 Topics: CSS, JavaScript, Progressive Web Apps  
 https://twitter.com/mxbck
 
 <img src="https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg" height="70px" width="auto" align="left" />
-
 Max Stoiber  
 Topics: React, Styled Components, OSS  
 https://twitter.com/mxstbr
 
 <img src="https://pbs.twimg.com/profile_images/814140031237496832/G-OShJRF_400x400.jpg" height="70px" width="auto" align="left" />
-
 Nik Graf  
 Topics: VR, Serverless, React  
 https://twitter.com/nikgraf
 
 <img src="https://pbs.twimg.com/profile_images/506474262278856704/V9E39edd_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Oliver Schöndorfer  
 Topics: Typography, CSS   
 https://twitter.com/glyphe
 
 <img src="https://pbs.twimg.com/profile_images/923184283367469057/HFTSuBcW_400x400.jpg" height="70px" width="auto" align="left" />
-
 Patrick Stapfer  
 Topics: ReasonML, Static Typing, Flow  
 https://twitter.com/ryyppy
 
 <img src="https://pbs.twimg.com/profile_images/868930803425828864/1TWl571x_400x400.jpg" height="70px" width="auto" align="left" />
-
 Peter Ferak  
 Topics: Functional Programming, Computer Science  
 https://twitter.com/ferakpeter
 
 <img src="https://pbs.twimg.com/profile_images/881236730254434304/JZs8wBHX_400x400.jpg" height="70px" width="auto" align="left" />
-
 Timo Obereder  
 Topics: React, Composition, Android, RXJava, Kotlin  
 https://twitter.com/defuex
@@ -245,7 +215,6 @@ https://twitter.com/defuex
 ### Hasselt
 
 <img src="https://pbs.twimg.com/profile_images/785464929948172288/SV_c8q7S_400x400.jpg" height="70px" width="auto" align="left" />
-
 Sam Bellen  
 Topics: Web Audio, Browser APIs  
 https://twitter.com/sambego
@@ -255,7 +224,6 @@ https://twitter.com/sambego
 ### Sofia
 
 <img src="https://pbs.twimg.com/profile_images/1267189835/rado_color_180_400x400.jpg" height="70px" width="auto" align="left" />
-
 Radoslav Stankov  
 Topics: React, Redux, Ruby, Testing, GraphQL  
 https://twitter.com/rstankov
@@ -265,19 +233,16 @@ https://twitter.com/rstankov
 ### Copenhagen
 
 <img src="https://pbs.twimg.com/profile_images/907970058625875968/7ecTxUP4_400x400.jpg" height="70px" width="auto" align="left" />
-
 Mathias Buus  
 Topics: Peer to Peer, Node.js  
 https://twitter.com/mafintosh
 
 <img src="https://pbs.twimg.com/profile_images/783752447940497408/R8S23hzW_400x400.jpg" height="70px" width="auto" align="left" />
-
 Olga Dmitricenko  
 Topics: VR, Web Image Processing  
 https://twitter.com/enthusiasto
 
 <img src="https://pbs.twimg.com/profile_images/824242201655910400/mY7NMaDE_400x400.jpg" height="70px" width="auto" align="left" />
-
 Tereza Sokol  
 Topics: Elm, Visualizations  
 https://twitter.com/terezk_a
@@ -287,7 +252,6 @@ https://twitter.com/terezk_a
 ### Helsinki
 
 <img src="https://pbs.twimg.com/profile_images/914150533820243970/DnBSM3RF_400x400.jpg" height="70px" width="auto" align="left" />
-
 Varya Stepanova  
 Topics: CSS in JS, Style Guides, Visual Regression Testing  
 https://twitter.com/varya_en
@@ -297,7 +261,6 @@ https://twitter.com/varya_en
 ### Strasbourg
 
 <img src="https://pbs.twimg.com/profile_images/805046964077400064/TYMf6IWP_400x400.jpg" height="70px" width="auto" align="left" />
-
 Sven Sauleau    
 Topics: JavaScript (Babel), Artificial Intelligence, Linux, Cloud, Ops, Computer Science    
 https://twitter.com/svensauleau
@@ -307,7 +270,6 @@ https://twitter.com/svensauleau
 ### Augsburg
 
 <img src="https://pbs.twimg.com/profile_images/715935523630669824/GJ1Xyp_s_400x400.jpg" height="70px" width="auto" align="left" />
-
 Johannes Ewald  
 Topics: Tooling, Standards, webpack  
 https://twitter.com/Jhnnns
@@ -315,61 +277,51 @@ https://twitter.com/Jhnnns
 ### Berlin
 
 <img src="https://pbs.twimg.com/profile_images/608674513241427968/ycianjI2_400x400.jpg" height="70px" width="auto" align="left" />
-
 Ally Long  
 Topics: CSS, Performance,  
 https://twitter.com/allyelle
 
 <img src="https://pbs.twimg.com/profile_images/770970370409201664/NtuKnExn_400x400.jpg" height="70px" width="auto" align="left" />
-
 Artem Sapegin  
 Topics: Styleguides, UI, CSS  
 https://twitter.com/iamsapegin
 
 <img src="https://pbs.twimg.com/profile_images/894641577557192704/ghN7wHa-_400x400.jpg" height="70px" width="auto" align="left" />
-
 Charlie Owen  
 Topics: CSS, Accessibility  
 https://twitter.com/sonniesedge
 
 <img src="https://pbs.twimg.com/profile_images/881401440098557952/HZzFErcN_400x400.jpg" height="70px" width="auto" align="left" />
-
 Hernán Magrini  
 Topics: Web Performance, Service Workers  
 https://twitter.com/hermagrini
 
 <img src="https://pbs.twimg.com/profile_images/858703912769081345/edLyRpPr_400x400.jpg" height="70px" width="auto" align="left" />
-
 Karl Horky  
 Topics: Tooling, Standards, (OSS), (Psychology)  
 https://twitter.com/karlhorky
 
 <img src="https://pbs.twimg.com/profile_images/908054663483838464/KFIQs9d3_400x400.jpg" height="70px" width="auto" align="left" />
-
 Lu Yu  
 Topics: Graphic Design, Typography, Branding, User Experience  
 https://twitter.com/Lugotype
 
 <img src="https://pbs.twimg.com/profile_images/2687722789/0146561e2d575b3e7104e7e94be62b1c_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Natalie Pistunovich  
 Topics: Mobile Apps, Go  
 https://twitter.com/nataliepis
 
 <img src="https://pbs.twimg.com/profile_images/754012456368963586/DOwDLy2k_400x400.jpg" height="70px" width="auto" align="left" />
-
 Oleg Slobodskoi  
 Topics: CSS in JS, React  
 https://twitter.com/oleg008
 
 <img src="https://pbs.twimg.com/profile_images/892332104012484608/_3R1X9CN_400x400.jpg" height="70px" width="auto" align="left" />
-
 Robin Pokorny  
 Topics: Jest, React, AMP, (Elm)  
 https://twitter.com/robinpokorny
 
 <img src="https://pbs.twimg.com/profile_images/889222391007719424/VZb5oY8a_400x400.jpg" height="70px" width="auto" align="left" />
-
 Yoshua Wuyts  
 Topics: Frameworks, Simplicity, Standards, Libraries  
 https://twitter.com/yoshuawuyts
@@ -377,7 +329,6 @@ https://twitter.com/yoshuawuyts
 ### Düsseldorf
 
 <img src="https://pbs.twimg.com/profile_images/768792268983701504/kIRa8QWM_400x400.jpg" height="70px" width="auto" align="left" />
-
 Joy Clark  
 Topics: Clojure, Web Apps, Security  
 https://twitter.com/iamjoyclark
@@ -385,7 +336,6 @@ https://twitter.com/iamjoyclark
 ### Freiburg
 
 <img src="https://2016.jsconf.is/71c6f10e201cfb70e77c61a513d62729.jpg" height="70px" width="auto" align="left" />
-
 Vitaly Friedman  
 Topics: Web Design, Web Development, Responsive Web Design  
 https://twitter.com/smashingmag
@@ -393,13 +343,11 @@ https://twitter.com/smashingmag
 ### Hamburg
 
 <img src="https://pbs.twimg.com/profile_images/2127157281/Martin_Kleppe_400x400.jpg" height="70px" width="auto" align="left" />
-
 Martin Kleppe  
 Topics: Weird JS  
 https://twitter.com/aemkei
 
 <img src="https://pbs.twimg.com/profile_images/530780279162429440/AeXURjRd_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Mauricio Palma  
 Topics: CSS, JavaScript  
 https://twitter.com/PalmaSwell
@@ -407,7 +355,6 @@ https://twitter.com/PalmaSwell
 ### Karlsruhe
 
 <img src="https://pbs.twimg.com/profile_images/925825609439301633/8lVHsfdV_400x400.jpg" height="70px" width="auto" align="left" />
-
 Robin Frischmann  
 Topics: CSS, CSS in JS, React  
 https://twitter.com/rofrischmann
@@ -415,13 +362,11 @@ https://twitter.com/rofrischmann
 ### Munich
 
 <img src="https://pbs.twimg.com/profile_images/661485440751509505/ZnNN9qes_400x400.jpg" height="70px" width="auto" align="left" />
-
 Franziska Hinkelmann  
 Topics: Node, V8  
 https://twitter.com/fhinkel
 
 <img src="https://pbs.twimg.com/profile_images/1255767431/kung-fu_400x400.jpg" height="70px" width="auto" align="left" />
-
 Mathias Bynens  
 Topics: JavaScript (TC39), V8, Chrome  
 https://twitter.com/mathias
@@ -431,13 +376,11 @@ https://twitter.com/mathias
 ### Dublin
 
 <img src="https://pbs.twimg.com/profile_images/775076695049113600/fTuBJGTA_400x400.jpg" height="70px" width="auto" align="left" />
-
 Ingrid Epure  
 Topics: Security, Psychology  
 https://twitter.com/ingridepure
 
 <img src="https://s.gravatar.com/avatar/55066ecb49b57ff9531581b8343aa4fa?size=140" height="70px" width="auto" align="left" />
-
 Serena Fritsch  
 Topics: JavaScript, Ember, Developer Workflows  
 https://twitter.com/serifritsch
@@ -445,19 +388,16 @@ https://twitter.com/serifritsch
 ## Israel 🇮🇱
 
 <img src="https://pbs.twimg.com/profile_images/736999006220455938/oczRgifS_400x400.jpg" height="70px" width="auto" align="left" />
-
 Nir Galon  
 Topics: Python, API Star, Open Source, Node.js, Angular  
 https://twitter.com/nirgn975
 
 <img src="https://pbs.twimg.com/profile_images/846618003085111296/mi84SWuu_400x400.jpg" height="70px" width="auto" align="left" />
-
 Nir Kaufman  
 Topics: Angular, Firebase, Redux  
 https://twitter.com/nirkaufman
 
 <img src="https://pbs.twimg.com/profile_images/668125552474062848/pTCvcmC3_400x400.jpg" height="70px" width="auto" align="left" />
-
 Uri Shaked  
 Topics: Web Bluetooth, Web VR, Angular, Internet of Things with JavaScript  
 https://twitter.com/UriShaked
@@ -467,7 +407,6 @@ https://twitter.com/UriShaked
 ### Milan
 
 <img src="https://pbs.twimg.com/profile_images/845799912222674945/70ofyabn_400x400.jpg" height="70px" width="auto" align="left" />
-
 Maurizio Mangione  
 Topics: Web Components, Polymer, Progressive Web Apps  
 https://twitter.com/granze
@@ -475,7 +414,6 @@ https://twitter.com/granze
 ## Verona
 
 <img src="https://pbs.twimg.com/profile_images/873084382235418625/qckzbrGr_400x400.jpg" height="70px" width="auto" align="left" />
-
 Matteo Ronchi  
 Topics: React, JavaScript, Flow, Web Architectures, Frontend Ops  
 https://twitter.com/cef62
@@ -485,31 +423,26 @@ https://twitter.com/cef62
 ### Amsterdam
 
 <img src="https://pbs.twimg.com/profile_images/905763629701660674/u7wBGyAa_400x400.jpg" height="70px" width="auto" align="left" />
-
 Alexey Kureev  
 Topics: React Native  
 https://twitter.com/kureevalexey
 
 <img src="https://pbs.twimg.com/profile_images/734378184918073348/j3bsV9Xk_400x400.jpg" height="70px" width="auto" align="left" />
-
 Carmen Popoviciu  
 Topics: Angular, JavaScript, Machine Learning, Neural Networks, Polymer, Web Components  
 https://twitter.com/carmenpopoviciu
 
 <img src="https://pbs.twimg.com/profile_images/852804703373074432/YVMyqpMW_400x400.jpg" height="70px" width="auto" align="left" />
-
 Kitze  
 Topics: MobX, State Management, GraphQL, CSS in JS  
 https://twitter.com/thekitze
 
 <img src="https://pbs.twimg.com/profile_images/661253444058005504/uO5nbrTL_bigger.jpg" height="70px" width="auto" align="left" />
-
 Michel Weststrate  
 Topics: MobX, React, mobx-state-tree, Typescript, Open Source  
 https://twitter.com/mweststrate
 
 <img src="https://pbs.twimg.com/profile_images/859482903763460098/565FGTxs_400x400.jpg" height="70px" width="auto" align="left" />
-
 Narendra Shetty  
 Topics: React, PWA  
 https://twitter.com/narendra_shetty
@@ -517,7 +450,6 @@ https://twitter.com/narendra_shetty
 ### Zwolle
 
 <img src="https://pbs.twimg.com/profile_images/722165598579507205/l4QzAmu8_400x400.jpg" height="70px" width="auto" align="left" />
-
 Norbert de Langen  
 Topics: Component Libraries, React, Storybook, Open Source, Communities  
 https://twitter.com/NorbertdeLangen
@@ -527,7 +459,6 @@ https://twitter.com/NorbertdeLangen
 ### Gdańsk
 
 <img src="https://pbs.twimg.com/profile_images/910825228175069184/WC_iMm7-_400x400.jpg" height="70px" width="auto" align="left" />
-
 Kasia Jastrzębska  
 Topics: React, Redux, Async, CSS in JS, ClojureScript  
 https://twitter.com/kejt_bw
@@ -535,7 +466,6 @@ https://twitter.com/kejt_bw
 ### Krakow
 
 <img src="https://pbs.twimg.com/profile_images/378800000409145857/2224a7110f583fb0661ca7cfdf01ce76_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Anna Migas  
 Topics: HTML, CSS, JavaScript, Web Animations, Web Performance  
 https://twitter.com/szynszyliszys
@@ -543,7 +473,6 @@ https://twitter.com/szynszyliszys
 ### Poznań
 
 <img src="https://pbs.twimg.com/profile_images/858080114197880833/DXeDmf51_400x400.jpg" height="70px" width="auto" align="left" />
-
 Tomasz Łakomy  
 Topics: React, VR, jQuery  
 https://twitter.com/tlakomy
@@ -551,7 +480,6 @@ https://twitter.com/tlakomy
 ### Warsaw
 
 <img src="https://pbs.twimg.com/profile_images/889850940852973568/kqTZlAf5_400x400.jpg" height="70px" width="auto" align="left" />
-
 Aga Naplocha  
 Topics: CSS, Teaching Web Technologies  
 https://twitter.com/aganaplocha
@@ -559,7 +487,6 @@ https://twitter.com/aganaplocha
 ### Wrocław
 
 <img src="https://pbs.twimg.com/profile_images/910449258263916545/l0pbXflE_400x400.jpg" height="70px" width="auto" align="left" />
-
 Mike Grabowski  
 Topics: React Native, JavaScript, Tooling  
 https://twitter.com/grabbou
@@ -569,13 +496,11 @@ https://twitter.com/grabbou
 ### Lisbon
 
 <img src="https://pbs.twimg.com/profile_images/841594344658391043/xh_QO-C9_400x400.jpg" height="70px" width="auto" align="left" />
-
 Daniela Matos de Carvalho  
 Topics: HTTP/2, JavaScript, React, Offline First  
 https://twitter.com/sericaia
 
 <img src="https://pbs.twimg.com/profile_images/849780545823195136/afw55D2y_400x400.jpg" height="70px" width="auto" align="left" />
-
 David Dias  
 Topics: IPFS, P2P, JavaScript, Node.js  
 https://twitter.com/daviddias
@@ -583,7 +508,6 @@ https://twitter.com/daviddias
 ### Porto
 
 <img src="https://pbs.twimg.com/profile_images/926881997863211008/WMzMYyCe_400x400.jpg" height="70px" width="auto" align="left" />
-
 Sara Vieira  
 Topics: Styleguides, React, CSS  
 https://twitter.com/NikkitaFTW
@@ -593,19 +517,16 @@ https://twitter.com/NikkitaFTW
 ### Moscow
 
 <img src="https://pbs.twimg.com/profile_images/486131556675616770/3695qr5w_400x400.png" height="70px" width="auto" align="left" />
-
 Nikita Prokopov  
 Topics: Clojure, DataScript, Rum, FiraCode, AnyBar  
 https://twitter.com/nikitonsky
 
 <img src="https://pbs.twimg.com/profile_images/880419066833510400/xJ1uiJUF_400x400.jpg" height="70px" width="auto" align="left" />
-
 Sergey Rubanov  
 Topics: Standards, Web Assembly  
 https://twitter.com/chicoxyzzy
 
 <img src="http://fpconf.ru/images/sobolev.jpg" height="70px" width="auto" align="left" />
-
 Nikita Sobolev  
 Topics: Elixir, Python  
 https://twitter.com/elixir_lang_mos
@@ -615,13 +536,11 @@ https://twitter.com/elixir_lang_mos
 ### Belgrade
 
 <img src="https://pbs.twimg.com/profile_images/823894615145201664/0xxSg0_c_400x400.jpg" height="70px" width="auto" align="left" />
-
 Aleksandar Simovic  
 Topics: Serverless  
 https://twitter.com/simalexan
 
 <img src="https://pbs.twimg.com/profile_images/858708563488845829/bfs-19gk_400x400.jpg" height="70px" width="auto" align="left" />
-
 Slobodan Stojanović  
 Topics: Serverless, Offline Web, Chat Bots  
 [https://twitter.com/slobodan_](https://twitter.com/slobodan_)
@@ -631,7 +550,6 @@ Topics: Serverless, Offline Web, Chat Bots
 ### Córdoba
 
 <img src="https://pbs.twimg.com/profile_images/916227643913244672/uR9VcF3B_400x400.jpg" height="70px" width="auto" align="left" />
-
 Javi Velasco  
 Topics: React, CSS in JS, React Toolbox  
 https://twitter.com/javivelasco
@@ -639,7 +557,6 @@ https://twitter.com/javivelasco
 ### Santander
 
 <img src="https://pbs.twimg.com/profile_images/1330141226/avatar-500_400x400.png" height="70px" width="auto" align="left" />
-
 Erik Rasmussen  
 Topics: React, Redux, Redux-Form, Forms  
 https://twitter.com/erikras
@@ -649,13 +566,11 @@ https://twitter.com/erikras
 ### Zurich
 
 <img src="https://pbs.twimg.com/profile_images/772017431376175104/XvIsVuB4_400x400.jpg" height="70px" width="auto" align="left" />
-
 Martin Splitt  
 Topics: VR, Web Performance  
 https://twitter.com/g33konaut
 
 <img src="https://pbs.twimg.com/profile_images/737308641511002113/YB7CH5CE_400x400.jpg" height="70px" width="auto" align="left" />
-
 Sebastian Siemssen  
 Topics: React, GraphQL, Tooling  
 https://twitter.com/thefubhy
@@ -665,13 +580,11 @@ https://twitter.com/thefubhy
 ### Kyiv
 
 <img src="https://pbs.twimg.com/profile_images/918401186516160512/aTJN_ydF_400x400.jpg" height="70px" width="auto" align="left" />
-
 Gregory Shehet  
 Topics: Functional Reactive Programming, MobX, CSS in JS, React  
 https://twitter.com/AGambit95
 
 <img src="https://pbs.twimg.com/profile_images/908763932747288576/ySuitABV_400x400.jpg" height="70px" width="auto" align="left" />
-
 Roman Liutikov  
 Topics: ClojureScript, React, Compilers  
 https://twitter.com/roman01la
@@ -681,7 +594,6 @@ https://twitter.com/roman01la
 ### Birmingham
 
 <img src="https://pbs.twimg.com/profile_images/807277326539046912/EZR6qL-S_400x400.jpg" height="70px" width="auto" align="left" />
-
 Bruce Lawson  
 Topics: Standards, Performance  
 https://twitter.com/brucel
@@ -689,13 +601,11 @@ https://twitter.com/brucel
 ### Brighton
 
 <img src="https://pbs.twimg.com/profile_images/727173860764844032/0hGX9DZG_400x400.jpg" height="70px" width="auto" align="left" />
-
 Jeremy Keith  
 Topics: Standards, Web Development, Web Design, CSS, Accessibility  
 https://twitter.com/adactio
 
 <img src="https://pbs.twimg.com/profile_images/526405732330004483/Cq5RGV8S_400x400.png" height="70px" width="auto" align="left" />
-
 Paul Robert Lloyd  
 Topics: Design, Web Design, Architecture, Design Systems, Trains  
 https://twitter.com/paulrobertlloyd
@@ -703,13 +613,11 @@ https://twitter.com/paulrobertlloyd
 ### Bristol
 
 <img src="https://pbs.twimg.com/profile_images/781380559947915265/wrjtv_jp_400x400.jpg" height="70px" width="auto" align="left" />
-
 Rachel Andrew  
 Topics: CSS  
 https://twitter.com/rachelandrew
 
 <img src="https://pbs.twimg.com/profile_images/820304800478658562/V20lAtva_400x400.jpg" height="70px" width="auto" align="left" />
-
 Ruth John  
 Topics: CSS Animations  
 https://twitter.com/Rumyra
@@ -717,7 +625,6 @@ https://twitter.com/Rumyra
 ### Leighton Buzzard
 
 <img src="https://pbs.twimg.com/profile_images/528613343381032960/aFnqmqcK_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Caroline Jarrett  
 Topics: Forms Usability, User Research  
 https://twitter.com/cjforms
@@ -725,49 +632,41 @@ https://twitter.com/cjforms
 ### London
 
 <img src="https://pbs.twimg.com/profile_images/925719098042052610/y-llZ0AF_400x400.jpg" height="70px" width="auto" align="left" />
-
 Ada Rose Cannon  
 Topics: HTML, CSS, JavaScript, WebVR, Web Technologies, Progressive Web Apps  
 https://twitter.com/lady_ada_king
 
 <img src="https://pbs.twimg.com/profile_images/865146773244858369/YxOo7hIC_400x400.jpg" height="70px" width="auto" align="left" />
-
 Alessandro Cinelli  
 Topics: JavaScript  
 https://twitter.com/cirpo
 
 <img src="https://pbs.twimg.com/profile_images/1540939151/whereIsAlexWithGlasses_400x400.jpg" height="70px" width="auto" align="left" />
-
 Alex Lobera  
 Topics: JavaScript, React, Redux, GraphQL  
 https://twitter.com/alex_lobera  
 
 <img src="https://pbs.twimg.com/profile_images/920632138013298689/TdWXZUfN_400x400.jpg" height="70px" width="auto" align="left" />
-
 Alexandra Deschamps-Sonsino  
 Topics: Internet of Things, Smart Homes, Connected Devices  
 https://twitter.com/iotwatch
 
 <img src="https://pbs.twimg.com/profile_images/518444104854679552/aU3S4Wji_400x400.png" height="70px" width="auto" align="left" />
-
 Alla Kholmatova  
 Topics: Design Systems  
 https://twitter.com/craftui
 
 <img src="https://pbs.twimg.com/profile_images/923316049050783744/HQTS2EsC_400x400.jpg" height="70px" width="auto" align="left" />
-
 Andrew Betts  
 Topics: Networks, Performance, Web  
 https://twitter.com/triblondon
 
 <img src="https://pbs.twimg.com/profile_images/829282867020722177/el35E312_400x400.jpg" height="70px" width="auto" align="left" />
-
 Anna Doubková  
 Topics: React, Testing  
 https://twitter.com/lithinn
 
 <img src="https://avatars0.githubusercontent.com/u/17880?s=400&v=4" height="70px" width="auto" align="left" />
-
 Bodil Stokke  
 Topics: Programming, Functional Programming  
 https://twitter.com/bodil
@@ -779,43 +678,36 @@ Topics: JS, RXJS, Angular, React
 https://twitter.com/chris_noring  
 
 <img src="https://pbs.twimg.com/profile_images/818604518820679683/pJd1hqvC_400x400.jpg" height="70px" width="auto" align="left" />
-
 Cristiano Rastelli  
 Topics: CSS, CSS in JS  
 https://twitter.com/areaweb
 
 <img src="https://pbs.twimg.com/profile_images/906557353549598720/oapgW_Fp_400x400.jpg" height="70px" width="auto" align="left" />
-
 Dan Abramov  
 Topics: JavaScript, React, Redux, Tooling  
 https://twitter.com/dan_abramov
 
 <img src="https://pbs.twimg.com/profile_images/880760574501679105/i_iXmIbn_400x400.jpg" height="70px" width="auto" align="left" />
-
 Davide 'Folletto' Casali  
 Topics: Design, User Experience, Management, Leadership, Startup  
 https://twitter.com/Folletto
 
 <img src="https://pbs.twimg.com/profile_images/796861611030024192/pVl1eq7f_400x400.jpg" height="70px" width="auto" align="left" />
-
 Gerard Sans  
 Topics: Angular, React, GraphQL, CSS Animations, RxJS  
 https://twitter.com/gerardsans
 
 <img src="https://pbs.twimg.com/profile_images/875454858215780352/etiz5li-_400x400.jpg" height="70px" width="auto" align="left" />
-
 Gojko Adzic  
 Topics: Testing, Requirements, Serverless  
 https://twitter.com/gojkoadzic
 
 <img src="https://pbs.twimg.com/profile_images/736631175985434624/yYKH74aG_400x400.jpg" height="70px" width="auto" align="left" />
-
 Michele Bertoli  
 Topics: React, Testing  
 https://twitter.com/MicheleBertoli
 
 <img src="https://pbs.twimg.com/profile_images/755148129968787457/iQ16fdT9_400x400.jpg" height="70px" width="auto" align="left" />
-
 Phil Plückthun  
 Topics: React, CSS in JS  
 https://twitter.com/_philpl
@@ -834,7 +726,6 @@ https://twitter.com/sebawita
 
 
 <img src="https://pbs.twimg.com/profile_images/684731880923639808/4nBLZm9n_400x400.jpg" height="70px" width="auto" align="left" />
-
 Inayaili de León  
 Topics: Design Systems, Responsive Web Design, Design Leadership, UI  
 https://twitter.com/yaili
@@ -842,7 +733,6 @@ https://twitter.com/yaili
 ## Norwich
 
 <img src="https://pbs.twimg.com/profile_images/915986359529111552/G2I0qF5G_400x400.jpg" height="70px" width="auto" align="left" />
-
 Heydon Pickering  
 Topics: Accessibility, Performance, Web  
 https://twitter.com/heydonworks
@@ -862,13 +752,11 @@ https://twitter.com/shehackspurple
 ### Toronto
 
 <img src="https://pbs.twimg.com/profile_images/912036800960405509/PU-_d_C2_400x400.jpg" height="70px" width="auto" align="left" />
-
 Brenna O'Brien  
 Topics: Motivation, Psychology, Developer Culture, Public Speaking  
 https://twitter.com/brnnbrn
 
 <img src="https://pbs.twimg.com/profile_images/646718876395311104/VxpVI-O6_400x400.jpg" height="70px" width="auto" align="left" />
-
 Tiff Nogueira   
 Topics: CSS Grids, React, Redux, Firebase, Flexbox   
 https://twitter.com/tiffcodes
@@ -878,13 +766,11 @@ https://twitter.com/tiffcodes
 ### Boston
 
 <img src="https://pbs.twimg.com/profile_images/832031365071773696/kDchWPLv_400x400.jpg" height="70px" width="auto" align="left" />
-
 Gleb Bahmutov  
 Topics: Computer Science, JavaScript, Reactive Programming  
 https://twitter.com/bahmutov &bull; https://slides.com/bahmutov &bull; https://glebbahmutov.com/videos
 
 <img src="https://pbs.twimg.com/profile_images/584963092120899586/TxkxQ7Y5_400x400.png" height="70px" width="auto" align="left" />
-
 Lea Verou  
 Topics: CSS, HTML  
 https://twitter.com/leaverou
@@ -892,7 +778,6 @@ https://twitter.com/leaverou
 ### Carlsbad
 
 <img src="https://pbs.twimg.com/profile_images/902276500107362304/vju-WV1i_400x400.jpg" height="70px" width="auto" align="left" />
-
 Michael Jackson  
 Topics: React, JavaScript, React Router  
 https://twitter.com/mjackson
@@ -908,7 +793,6 @@ https://twitter.com/gigasquid
 ### Denver
 
 <img src="https://pbs.twimg.com/profile_images/923079722778505216/qhL5tFpp_400x400.jpg" height="70px" width="auto" align="left" />
-
 Miriam Suzanne  
 Topics: CSS, Sass, Architecture, Design Systems  
 https://twitter.com/mirisuzanne
@@ -916,7 +800,6 @@ https://twitter.com/mirisuzanne
 ### Midwest
 
 <img src="https://pbs.twimg.com/profile_images/873189682242367489/ereVA7Ub_400x400.jpg" height="70px" width="auto" align="left" />
-
 Levi Bostian  
 Topics: Android, RxJava, Kotlin, Freelancing, Swift, iOS, Productivity, Startups, Bootstrapping
 https://twitter.com/levibostian
@@ -924,7 +807,6 @@ https://twitter.com/levibostian
 ### Nashville
 
 <img src="https://pbs.twimg.com/profile_images/899001646679814145/4TU9HfO-_400x400.jpg" height="70px" width="auto" align="left" />
-
 Aimee Knight  
 Topics: JavaScript, CSS, Angular, Growing Junior Developers  
 https://twitter.com/Aimee_Knight
@@ -932,7 +814,6 @@ https://twitter.com/Aimee_Knight
 ### New Jersey
 
 <img src="https://pbs.twimg.com/profile_images/918655507698679808/B8xrPFCs_400x400.jpg" height="70px" width="auto" align="left" />
-
 Ken Wheeler  
 Topics: React, React Native, ReasonML  
 https://twitter.com/ken_wheeler
@@ -940,13 +821,11 @@ https://twitter.com/ken_wheeler
 ### New Orleans
 
 <img src="https://pbs.twimg.com/profile_images/417667937105752064/Z6SeM2_a_400x400.png" height="70px" width="auto" align="left" />
-
 Gant Laborde  
 Topics:  JavaScript, React Native, Leadership, Redux, Open Source, Tooling, Public Speaking  
 https://twitter.com/GantLaborde
 
 <img src="https://pbs.twimg.com/profile_images/861717239002562560/r01NX6n0_400x400.jpg" height="70px" width="auto" align="left" />
-
 Sia Karamalegos  
 Topics: React, JavaScript, React Native, Front-End Performance  
 https://twitter.com/thegreengreek
@@ -954,49 +833,41 @@ https://twitter.com/thegreengreek
 ### New York
 
 <img src="https://pbs.twimg.com/profile_images/62572418/me_400x400.jpg" height="70px" width="auto" align="left" />
-
 David Nolen  
 Topics: Clojure, ClojureScript, Om, Functional Programming, Computer Science  
 https://twitter.com/swannodette
 
 <img src="https://pbs.twimg.com/profile_images/412413402749743107/jOnza-Eg_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Diana Mounter  
 Topics: Design Systems, CSS, Product Design  
 https://twitter.com/broccolini
 
 <img src="https://pbs.twimg.com/profile_images/432754023385403393/6lc-7Xqg_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Henry Zhu  
 Topics: Open Source, Babel  
 https://twitter.com/left_pad
 
 <img src="https://pbs.twimg.com/profile_images/765902179660161024/zCC2yj_R_400x400.jpg" height="70px" width="auto" align="left" />
-
 Jen Simmons  
 Topics: CSS, HTML, Web  
 https://twitter.com/jensimmons
 
 <img src="https://pbs.twimg.com/profile_images/849322587909967874/pOMAg5VX_400x400.jpg" height="70px" width="auto" align="left" />
-
 Lara Hogan  
 Topics: Design, Performance, Engineering Management, Public Speaking  
 https://twitter.com/lara_hogan
 
 <img src="https://pbs.twimg.com/profile_images/896883376954757120/gXtYevrr_400x400.jpg" height="70px" width="auto" align="left" />
-
 Kurtis Kemple  
 Topics: React, React Native, GraphQL, Universal Components  
 https://twitter.com/kurtiskemple
 
 <img src="https://pbs.twimg.com/profile_images/593793041816629248/yKbOT56n_400x400.jpg" height="70px" width="auto" align="left" />
-
 Mariko Kosaka  
 Topics: HTML, CSS, JavaScript, Web  
 https://twitter.com/kosamari
 
 <img src="https://pbs.twimg.com/profile_images/783341508820893696/JphRM0xk_400x400.jpg" height="70px" width="auto" align="left" />
-
 Peggy Rayzis  
 Topics: React, React Native, GraphQL  
 https://twitter.com/peggyrayzis
@@ -1010,13 +881,11 @@ https://twitter.com/una
 ### Philadelphia
 
 <img src="https://pbs.twimg.com/profile_images/462071677317160960/fvsOcwr1_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Lis Pardi  
 Topics: Web  
 https://twitter.com/lispardi
 
 <img src="https://pbs.twimg.com/profile_images/635812303342956545/Fo4RyEgH_400x400.jpg" height="70px" width="auto" align="left" />
-
 Richard Feldman  
 Topics: Elm  
 https://twitter.com/rtfeldman
@@ -1024,13 +893,11 @@ https://twitter.com/rtfeldman
 ### Pittsburgh
 
 <img src="https://pbs.twimg.com/profile_images/907811115459125248/i8AzK6gR_400x400.jpg" height="70px" width="auto" align="left" />
-
 Brad Frost  
 Topics: Web Design, Atomic Design, Web Development  
 https://twitter.com/brad_frost
 
 <img src="https://pbs.twimg.com/profile_images/497876628651782146/hrCHz_ym_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Lin Clark  
 Topics: React, WebAssembly, Browsers Internals  
 https://twitter.com/linclark
@@ -1038,13 +905,11 @@ https://twitter.com/linclark
 ### Portland
 
 <img src="https://pbs.twimg.com/profile_images/786039150667411456/t_0mWTZk_400x400.jpg" height="70px" width="auto" align="left" />
-
 Kyle Shevlin  
 Topics: React, Redux, JavaScript  
 https://twitter.com/kyleshevlin
 
 <img src="https://pbs.twimg.com/profile_images/684146011564933120/eUohVcRB_400x400.jpg" height="70px" width="auto" align="left" />
-
 Micah Godbolt  
 Topics: Front-End Architecture, CSS, Design Systems  
 https://twitter.com/micahgodbolt
@@ -1060,103 +925,86 @@ https://twitter.com/kentcdodds
 ### San Francisco
 
 <img src="https://pbs.twimg.com/profile_images/657238456280731648/YvIabjlq_400x400.png" height="70px" width="auto" align="left" />
-
 Anjana Vakil  
 Topics: Programming Language Paradigms, Functional Programming (with JavaScript)  
 https://twitter.com/AnjanaVakil
 
 <img src="https://pbs.twimg.com/profile_images/745127659340861440/qKoNl3zu_400x400.jpg" height="70px" width="auto" align="left" />
-
 Beth Dean  
 Topics: Design, Illustration  
 https://twitter.com/bethdean
 
 <img src="https://pbs.twimg.com/profile_images/773213042477637632/Nc8d6VZg_400x400.jpg" height="70px" width="auto" align="left" />
-
 Adam Menges  
 Topics: Artificial Intelligence, Design, Computer Science  
 https://twitter.com/adammenges &bull; https://instagram.com/adammenges
 
 <img src="https://pbs.twimg.com/profile_images/880565020173717504/CqM1jdvu_400x400.jpg" height="70px" width="auto" align="left" />
-
 Boris Cherny  
 Topics: TypeScript, React, Computer Science  
 https://twitter.com/bcherny
 
 <img src="https://pbs.twimg.com/profile_images/451517791091167232/ycYsDdzq_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Brynn Evans  
 Topics: Design, Management  
 https://twitter.com/brynn
 
 <img src="https://pbs.twimg.com/profile_images/744899510/avatar_400x400.png" height="70px" width="auto" align="left" />
-
 Estelle Weyl  
 Topics: CSS, Performance, Responsive Web Design  
 https://twitter.com/standardista
 
 <img src="https://pbs.twimg.com/profile_images/491609678539792384/YskBOQeH_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Jafar Husain  
 Topics: JavaScript, ES7, Observables, Reactive Programming, Falcor  
 https://twitter.com/jhusain
 
 <img src="https://pbs.twimg.com/profile_images/922512926711332864/qAY-xrsm_400x400.jpg" height="70px" width="auto" align="left" />
-
 Jon Gold  
 Topics: Design, Design Systems, React, Artificial Intelligence  
 https://twitter.com/jongold
 
 <img src="https://avatars1.githubusercontent.com/u/12424987?s=460&v=4" height="70px" width="auto" align="left" />
-
 Lisa Huang  
 Topics: AMP, Offline-First Mobile Apps, React  
 https://twitter.com/lisaychuang
 
 <img src="https://pbs.twimg.com/profile_images/767888976166268928/Ieds3b1K_400x400.jpg" height="70px" width="auto" align="left" />
-
 Mike Matas  
 Topics: Human Interface Design  
 https://twitter.com/mike_matas &bull; https://instagram.com/mike_matas
 
 <img src="https://pbs.twimg.com/profile_images/818997879696195584/1_vmf7bc_400x400.jpg" height="70px" width="auto" align="left" />
-
 Mina Markham  
 Topics: CSS Architecture, Sass, Community, Design Systems  
 https://twitter.com/MinaMarkham
 
 <img src="https://pbs.twimg.com/profile_images/779808817785675776/Hf9AwdFs_400x400.jpg" height="70px" width="auto" align="left" />
-
 Monica Dinculescu  
 Topics: Web Components, Polymer, Emoji  
 https://twitter.com/notwaldorf
 
 <img src="https://pbs.twimg.com/profile_images/865264595195265024/EuTAyJFJ_400x400.jpg" height="70px" width="auto" align="left" />
-
 Preethi Kasireddy  
 Topics: Machine Learning, Natural Language Processing, React  
 https://twitter.com/iam_preethi
 
 <img src="https://pbs.twimg.com/profile_images/856249108885110784/97cssCek_400x400.jpg" height="70px" width="auto" align="left" />
-
 Sarah Drasner  
 Topics: CSS, SVG, Animations, Vue.js, React  
 https://twitter.com/sarah_edo
 
 <img src="https://pbs.twimg.com/profile_images/913444398133735427/7zjUK6pp_400x400.jpg" height="70px" width="auto" align="left" />
-
 Sean Grove  
 Topics: GraphQL, ReasonML, OCaml  
 https://twitter.com/sgrove
 
 <img src="https://pbs.twimg.com/profile_images/847556940028923905/xlh3pLCr_400x400.jpg" height="70px" width="auto" align="left" />
-
 Stephanie Rewis  
 Topics: Design Systems, CSS  
 https://twitter.com/stefsull
 
 <img src="https://pbs.twimg.com/profile_images/821783522427834369/SOIW4xGP_400x400.jpg" height="70px" width="auto" align="left" />
-
 Tracy Lee  
 Topics: Reactive Programming, Angular, Ember.js  
 https://twitter.com/ladyleet
@@ -1168,17 +1016,15 @@ https://twitter.com/ladyleet
 ### Buenos Aires
 
 <img src="https://pbs.twimg.com/profile_images/540127281490845697/_2zxxUOt_400x400.jpeg" height="70px" width="auto" align="left" />
-
 Evangelina Ferreira   
 Topics: CSS, Animations   
 https://twitter.com/evaferreira92
 
 ## Brazil 🇧🇷
 
-### Belo Horizonte 
+### Belo Horizonte
 
 <img src="https://pbs.twimg.com/profile_images/880632277188972544/iHbGo43-_400x400.jpg" height="70px" width="auto" align="left" />
-
 Beto Muniz  
 Topics: React, JavaScript, PWA, Polymer, Community  
 https://twitter.com/obetomuniz
@@ -1186,7 +1032,6 @@ https://twitter.com/obetomuniz
 ### Curitiba
 
 <img src="https://pbs.twimg.com/profile_images/824222313470169088/Te_e1i1f_400x400.jpg" height="70px" width="auto" align="left" />
-
 Fernando Daciuk  
 Topics: React, JavaScript  
 https://twitter.com/fdaciuk

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Please add to the list and help make the community better connected and richer.
 ## Nigeria 🇳🇬
 
 <img src="https://pbs.twimg.com/profile_images/911164658047963136/SLtLXQQp_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Ire Aderinokun" />
+
 Ire Aderinokun  
 Topics: PWA, CSS, Standards  
 https://twitter.com/ireaderinokun   
@@ -23,16 +24,19 @@ https://twitter.com/ireaderinokun
 ### Bangalore
 
 <img src="https://avatars3.githubusercontent.com/u/1382793?s=460&v=4" height="70px" width="auto" align="left" alt="Headshot of Ashrith Kulai" />
+
 Ashrith Kulai  
 Topics: PWA, Polymer, Web Components, Web Performance, Build Tools  
 https://twitter.com/ashrith_kulai  
 
 <img src="https://i.imgur.com/OXCWwy7.jpg" height="70px" width="auto" align="left" alt="Headshot of Kumar Anirudha" />
+
 Kumar Anirudha  
 Topics: Python, Node.js, Blockchain, Architecture, Cryptocurrency  
 https://twitter.com/kranirudha
 
 <img src="https://pbs.twimg.com/profile_images/895583823202668544/kFsLGKC3_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Siddharth Kshetrapal" />
+
 Siddharth Kshetrapal  
 Topics: CSS, Web Performance, React, CSS in JS, Node, Testing  
 https://twitter.com/siddharthkp
@@ -40,16 +44,19 @@ https://twitter.com/siddharthkp
 ### Mumbai
 
 <img src="https://pbs.twimg.com/profile_images/856209876732739585/rQcsMvCa_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Manjula Dube" />
+
 Manjula Dube  
 Topics: JavaScript, React, PWA, Node, Testing  
 https://twitter.com/manjula_dube
 
 <img src="https://pbs.twimg.com/profile_images/890131426217259008/6LEkT3eS_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Neehar Venugopal" />
+
 Neehar Venugopal  
 Topics: Code Splitting, Standards  
 https://twitter.com/neeharv
 
 <img src="https://pbs.twimg.com/profile_images/907656585752842250/PwI99gBG_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sidhartha Chatterjee" />
+
 Sidhartha Chatterjee  
 Topics: React, PWA, Web Performance  
 https://twitter.com/chatsidhartha
@@ -57,6 +64,7 @@ https://twitter.com/chatsidhartha
 ### New Delhi
 
 <img src="https://pbs.twimg.com/profile_images/514383461583294464/bIXQJcyG_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Arun Michael Dsouza" />
+
 Arun Michael Dsouza  
 Topics: webpack, React, ES6, Tooling, CSS  
 https://twitter.com/amdsouza92
@@ -66,6 +74,7 @@ https://twitter.com/amdsouza92
 ### Tyre
 
 <img src="https://pbs.twimg.com/profile_images/903537944320987136/wB28L8qd_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sara Soueidan" />
+
 Sara Soueidan  
 Topics: Animations, CSS, SVG  
 https://twitter.com/sarasoueidan
@@ -75,16 +84,19 @@ https://twitter.com/sarasoueidan
 ### Singapore
 
 <img src="https://pbs.twimg.com/profile_images/535685345472286720/9gjiNZiF_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Aysha Anggraini" />
+
 Aysha Anggraini  
 Topics: CSS, Animations  
 https://twitter.com/renettarenula
 
 <img src="https://pbs.twimg.com/profile_images/917359648524558336/Zu2sC6Jk_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Chen Hui Jing" />
+
 Chen Hui Jing  
 Topics: CSS  
 https://twitter.com/hj_chen
 
 <img src="https://pbs.twimg.com/profile_images/791843247312154625/UsLdWIIj_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Zell Liew" />
+
 Zell Liew  
 Topics: CSS, JavaScript  
 https://twitter.com/zellwk
@@ -96,21 +108,25 @@ https://twitter.com/zellwk
 ### Melbourne
 
 <img src="https://pbs.twimg.com/profile_images/683874690293612545/kDStZOBp_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Glen Maddern" />
+
 Glen Maddern  
 Topics: CSS, Styled Components, React, JavaScript  
 https://twitter.com/glenmaddern
 
 <img src="https://pbs.twimg.com/profile_images/898083700818169856/prj-so7C_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Karolina Szczur" />
+
 Karolina Szczur  
 Topics: CSS, HTML, Web, Inclusivity, Diversity  
 https://twitter.com/fox
 
 <img src="https://pbs.twimg.com/profile_images/754886061872979968/BzaOWhs1_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Mark Dalgleish" />
+
 Mark Dalgleish  
 Topics: Design Systems, Web Design  
 https://twitter.com/markdalgleish
 
 <img src="https://pbs.twimg.com/profile_images/789522857936220160/6OIm0gj0_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Phil Nash" />
+
 Phil Nash  
 Topics: JavaScript, Web Development, Progressive Web Apps  
 https://twitter.com/philnash
@@ -122,6 +138,7 @@ https://twitter.com/philnash
 ### Linz
 
 <img src="https://pbs.twimg.com/profile_images/572642811029426177/GxgFcPtm_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Stefan Baumgartner" />
+
 Stefan Baumgartner  
 Topics: Web Ops, JavaScript, CSS, Tooling  
 https://twitter.com/ddprrt
@@ -129,6 +146,7 @@ https://twitter.com/ddprrt
 ### Salzburg
 
 <img src="https://pbs.twimg.com/profile_images/861132772366331905/4xts32Lq_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Lisi Linhart" />
+
 Lisi Linhart  
 Topics: CSS, Web Animations  
 https://twitter.com/lisi_linhart
@@ -136,76 +154,91 @@ https://twitter.com/lisi_linhart
 ### Vienna
 
 <img src="https://pbs.twimg.com/profile_images/1492139238/profile_pic.jpg_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Ali Sharif" />
+
 Ali Sharif  
 Topics: Functional Programming, Agile, Product Development  
 https://twitter.com/sharifsbeat
 
 <img src="https://pbs.twimg.com/profile_images/678903331176214528/TQTdqGwD_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Andrey Okonetchnikov" />
+
 Andrey Okonetchnikov  
 Topics: CSS in JS, Linting, Tooling  
 https://twitter.com/okonetchnikov
 
 <img src="https://pbs.twimg.com/profile_images/831514456828026880/IeSbt2Nw_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Christoph Rumpel" />
+
 Christoph Rumpel  
 Topics: PHP, Laravel, Chatbots  
 https://twitter.com/christophrumpel
 
 <img src="https://pbs.twimg.com/profile_images/708910026245738496/CUhZSMYO_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Eva Lettner" />
+
 Eva Lettner  
 Topics: CSS, Web  
 https://twitter.com/eva_trostlos
 
 <img src="https://pbs.twimg.com/profile_images/687205014348103680/ZcIXYv4g_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Glenn Reyes" />
+
 Glenn Reyes  
 Topics: Code splitting, React  
 https://twitter.com/glnnrys
 
 <img src="https://pbs.twimg.com/profile_images/875719105839603712/_nJ_XRw1_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Jan Hruby" />
+
 Jan Hruby  
 Topics: React, Redux, CSS in JS, (React Native, Serverless, GraphQL)  
 https://twitter.com/mrozilla  
 
 <img src="https://pbs.twimg.com/profile_images/883661923107180544/OpPpk-Ku_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Juho Vepsäläinen" />
+
 Juho Vepsäläinen  
 Topics: 3D graphics, Business, React, webpack, Writing  
 https://twitter.com/bebraw
 
 <img src="https://pbs.twimg.com/profile_images/707504523678523392/Uasvv2C4_400x400.jpg" height="70" align="left"" alt="Headshot of Manuel Matuzović" />
+
 Manuel Matuzović  
 Topics: CSS, Accesibility  
 https://twitter.com/mmatuzo  
 
 <img src="https://pbs.twimg.com/profile_images/827473632351879169/ZnoB7yTR_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Max Böck" />
+
 Max Böck  
 Topics: CSS, JavaScript, Progressive Web Apps  
 https://twitter.com/mxbck
 
 <img src="https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Max Stoiber" />
+
 Max Stoiber  
 Topics: React, Styled Components, OSS  
 https://twitter.com/mxstbr
 
 <img src="https://pbs.twimg.com/profile_images/814140031237496832/G-OShJRF_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Nik Graf" />
+
 Nik Graf  
 Topics: VR, Serverless, React  
 https://twitter.com/nikgraf
 
 <img src="https://pbs.twimg.com/profile_images/506474262278856704/V9E39edd_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Oliver Schöndorfer" />
+
 Oliver Schöndorfer  
 Topics: Typography, CSS   
 https://twitter.com/glyphe
 
 <img src="https://pbs.twimg.com/profile_images/923184283367469057/HFTSuBcW_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Patrick Stapfer" />
+
 Patrick Stapfer  
 Topics: ReasonML, Static Typing, Flow  
 https://twitter.com/ryyppy
 
 <img src="https://pbs.twimg.com/profile_images/868930803425828864/1TWl571x_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Peter Ferak" />
+
 Peter Ferak  
 Topics: Functional Programming, Computer Science  
 https://twitter.com/ferakpeter
 
 <img src="https://pbs.twimg.com/profile_images/881236730254434304/JZs8wBHX_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Timo Obereder" />
+
 Timo Obereder  
 Topics: React, Composition, Android, RXJava, Kotlin  
 https://twitter.com/defuex
@@ -215,6 +248,7 @@ https://twitter.com/defuex
 ### Hasselt
 
 <img src="https://pbs.twimg.com/profile_images/785464929948172288/SV_c8q7S_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sam Bellen" />
+
 Sam Bellen  
 Topics: Web Audio, Browser APIs  
 https://twitter.com/sambego
@@ -224,6 +258,7 @@ https://twitter.com/sambego
 ### Sofia
 
 <img src="https://pbs.twimg.com/profile_images/1267189835/rado_color_180_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Radoslav Stankov" />
+
 Radoslav Stankov  
 Topics: React, Redux, Ruby, Testing, GraphQL  
 https://twitter.com/rstankov
@@ -233,16 +268,19 @@ https://twitter.com/rstankov
 ### Copenhagen
 
 <img src="https://pbs.twimg.com/profile_images/907970058625875968/7ecTxUP4_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Mathias Buus" />
+
 Mathias Buus  
 Topics: Peer to Peer, Node.js  
 https://twitter.com/mafintosh
 
 <img src="https://pbs.twimg.com/profile_images/783752447940497408/R8S23hzW_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Olga Dmitricenko" />
+
 Olga Dmitricenko  
 Topics: VR, Web Image Processing  
 https://twitter.com/enthusiasto
 
 <img src="https://pbs.twimg.com/profile_images/824242201655910400/mY7NMaDE_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Tereza Sokol" />
+
 Tereza Sokol  
 Topics: Elm, Visualizations  
 https://twitter.com/terezk_a
@@ -252,6 +290,7 @@ https://twitter.com/terezk_a
 ### Helsinki
 
 <img src="https://pbs.twimg.com/profile_images/914150533820243970/DnBSM3RF_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Varya Stepanova" />
+
 Varya Stepanova  
 Topics: CSS in JS, Style Guides, Visual Regression Testing  
 https://twitter.com/varya_en
@@ -261,6 +300,7 @@ https://twitter.com/varya_en
 ### Strasbourg
 
 <img src="https://pbs.twimg.com/profile_images/805046964077400064/TYMf6IWP_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sven Sauleau" />
+
 Sven Sauleau    
 Topics: JavaScript (Babel), Artificial Intelligence, Linux, Cloud, Ops, Computer Science    
 https://twitter.com/svensauleau
@@ -270,6 +310,7 @@ https://twitter.com/svensauleau
 ### Augsburg
 
 <img src="https://pbs.twimg.com/profile_images/715935523630669824/GJ1Xyp_s_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Johannes Ewald" />
+
 Johannes Ewald  
 Topics: Tooling, Standards, webpack  
 https://twitter.com/Jhnnns
@@ -277,51 +318,61 @@ https://twitter.com/Jhnnns
 ### Berlin
 
 <img src="https://pbs.twimg.com/profile_images/608674513241427968/ycianjI2_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Ally Long" />
+
 Ally Long  
 Topics: CSS, Performance,  
 https://twitter.com/allyelle
 
 <img src="https://pbs.twimg.com/profile_images/770970370409201664/NtuKnExn_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Artem Sapegin" />
+
 Artem Sapegin  
 Topics: Styleguides, UI, CSS  
 https://twitter.com/iamsapegin
 
 <img src="https://pbs.twimg.com/profile_images/894641577557192704/ghN7wHa-_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Charlie Owen" />
+
 Charlie Owen  
 Topics: CSS, Accessibility  
 https://twitter.com/sonniesedge
 
 <img src="https://pbs.twimg.com/profile_images/881401440098557952/HZzFErcN_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Hernán Magrini" />
+
 Hernán Magrini  
 Topics: Web Performance, Service Workers  
 https://twitter.com/hermagrini
 
 <img src="https://pbs.twimg.com/profile_images/858703912769081345/edLyRpPr_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Karl Horky" />
+
 Karl Horky  
 Topics: Tooling, Standards, (OSS), (Psychology)  
 https://twitter.com/karlhorky
 
 <img src="https://pbs.twimg.com/profile_images/908054663483838464/KFIQs9d3_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Lu Yu" />
+
 Lu Yu  
 Topics: Graphic Design, Typography, Branding, User Experience  
 https://twitter.com/Lugotype
 
 <img src="https://pbs.twimg.com/profile_images/2687722789/0146561e2d575b3e7104e7e94be62b1c_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Natalie Pistunovich" />
+
 Natalie Pistunovich  
 Topics: Mobile Apps, Go  
 https://twitter.com/nataliepis
 
 <img src="https://pbs.twimg.com/profile_images/754012456368963586/DOwDLy2k_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Oleg Slobodskoi" />
+
 Oleg Slobodskoi  
 Topics: CSS in JS, React  
 https://twitter.com/oleg008
 
 <img src="https://pbs.twimg.com/profile_images/892332104012484608/_3R1X9CN_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Robin Pokorny" />
+
 Robin Pokorny  
 Topics: Jest, React, AMP, (Elm)  
 https://twitter.com/robinpokorny
 
 <img src="https://pbs.twimg.com/profile_images/889222391007719424/VZb5oY8a_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Yoshua Wuyts" />
+
 Yoshua Wuyts  
 Topics: Frameworks, Simplicity, Standards, Libraries  
 https://twitter.com/yoshuawuyts
@@ -329,6 +380,7 @@ https://twitter.com/yoshuawuyts
 ### Düsseldorf
 
 <img src="https://pbs.twimg.com/profile_images/768792268983701504/kIRa8QWM_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Joy Clark" />
+
 Joy Clark  
 Topics: Clojure, Web Apps, Security  
 https://twitter.com/iamjoyclark
@@ -336,6 +388,7 @@ https://twitter.com/iamjoyclark
 ### Freiburg
 
 <img src="https://2016.jsconf.is/71c6f10e201cfb70e77c61a513d62729.jpg" height="70px" width="auto" align="left" alt="Headshot of Vitaly Friedman" />
+
 Vitaly Friedman  
 Topics: Web Design, Web Development, Responsive Web Design  
 https://twitter.com/smashingmag
@@ -343,11 +396,13 @@ https://twitter.com/smashingmag
 ### Hamburg
 
 <img src="https://pbs.twimg.com/profile_images/2127157281/Martin_Kleppe_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Martin Kleppe" />
+
 Martin Kleppe  
 Topics: Weird JS  
 https://twitter.com/aemkei
 
 <img src="https://pbs.twimg.com/profile_images/530780279162429440/AeXURjRd_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Mauricio Palma" />
+
 Mauricio Palma  
 Topics: CSS, JavaScript  
 https://twitter.com/PalmaSwell
@@ -355,6 +410,7 @@ https://twitter.com/PalmaSwell
 ### Karlsruhe
 
 <img src="https://pbs.twimg.com/profile_images/925825609439301633/8lVHsfdV_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Robin Frischmann" />
+
 Robin Frischmann  
 Topics: CSS, CSS in JS, React  
 https://twitter.com/rofrischmann
@@ -362,11 +418,13 @@ https://twitter.com/rofrischmann
 ### Munich
 
 <img src="https://pbs.twimg.com/profile_images/661485440751509505/ZnNN9qes_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Franziska Hinkelmann" />
+
 Franziska Hinkelmann  
 Topics: Node, V8  
 https://twitter.com/fhinkel
 
 <img src="https://pbs.twimg.com/profile_images/1255767431/kung-fu_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Mathias Bynens" />
+
 Mathias Bynens  
 Topics: JavaScript (TC39), V8, Chrome  
 https://twitter.com/mathias
@@ -376,11 +434,13 @@ https://twitter.com/mathias
 ### Dublin
 
 <img src="https://pbs.twimg.com/profile_images/775076695049113600/fTuBJGTA_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Ingrid Epure" />
+
 Ingrid Epure  
 Topics: Security, Psychology  
 https://twitter.com/ingridepure
 
 <img src="https://s.gravatar.com/avatar/55066ecb49b57ff9531581b8343aa4fa?size=140" height="70px" width="auto" align="left" alt="Headshot of Serena Fritsch" />
+
 Serena Fritsch  
 Topics: JavaScript, Ember, Developer Workflows  
 https://twitter.com/serifritsch
@@ -388,16 +448,19 @@ https://twitter.com/serifritsch
 ## Israel 🇮🇱
 
 <img src="https://pbs.twimg.com/profile_images/736999006220455938/oczRgifS_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Nir Galon" />
+
 Nir Galon  
 Topics: Python, API Star, Open Source, Node.js, Angular  
 https://twitter.com/nirgn975
 
 <img src="https://pbs.twimg.com/profile_images/846618003085111296/mi84SWuu_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Nir Kaufman" />
+
 Nir Kaufman  
 Topics: Angular, Firebase, Redux  
 https://twitter.com/nirkaufman
 
 <img src="https://pbs.twimg.com/profile_images/668125552474062848/pTCvcmC3_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Uri Shaked" />
+
 Uri Shaked  
 Topics: Web Bluetooth, Web VR, Angular, Internet of Things with JavaScript  
 https://twitter.com/UriShaked
@@ -407,6 +470,7 @@ https://twitter.com/UriShaked
 ### Milan
 
 <img src="https://pbs.twimg.com/profile_images/845799912222674945/70ofyabn_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Maurizio Mangione" />
+
 Maurizio Mangione  
 Topics: Web Components, Polymer, Progressive Web Apps  
 https://twitter.com/granze
@@ -414,6 +478,7 @@ https://twitter.com/granze
 ## Verona
 
 <img src="https://pbs.twimg.com/profile_images/873084382235418625/qckzbrGr_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Matteo Ronchi" />
+
 Matteo Ronchi  
 Topics: React, JavaScript, Flow, Web Architectures, Frontend Ops  
 https://twitter.com/cef62
@@ -423,26 +488,31 @@ https://twitter.com/cef62
 ### Amsterdam
 
 <img src="https://pbs.twimg.com/profile_images/905763629701660674/u7wBGyAa_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Alexey Kureev" />
+
 Alexey Kureev  
 Topics: React Native  
 https://twitter.com/kureevalexey
 
 <img src="https://pbs.twimg.com/profile_images/734378184918073348/j3bsV9Xk_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Carmen Popoviciu" />
+
 Carmen Popoviciu  
 Topics: Angular, JavaScript, Machine Learning, Neural Networks, Polymer, Web Components  
 https://twitter.com/carmenpopoviciu
 
 <img src="https://pbs.twimg.com/profile_images/852804703373074432/YVMyqpMW_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Kitze" />
+
 Kitze  
 Topics: MobX, State Management, GraphQL, CSS in JS  
 https://twitter.com/thekitze
 
 <img src="https://pbs.twimg.com/profile_images/661253444058005504/uO5nbrTL_bigger.jpg" height="70px" width="auto" align="left" alt="Headshot of Michel Weststrate" />
+
 Michel Weststrate  
 Topics: MobX, React, mobx-state-tree, Typescript, Open Source  
 https://twitter.com/mweststrate
 
 <img src="https://pbs.twimg.com/profile_images/859482903763460098/565FGTxs_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Narendra Shetty" />
+
 Narendra Shetty  
 Topics: React, PWA  
 https://twitter.com/narendra_shetty
@@ -450,6 +520,7 @@ https://twitter.com/narendra_shetty
 ### Zwolle
 
 <img src="https://pbs.twimg.com/profile_images/722165598579507205/l4QzAmu8_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Norbert de Langen" />
+
 Norbert de Langen  
 Topics: Component Libraries, React, Storybook, Open Source, Communities  
 https://twitter.com/NorbertdeLangen
@@ -459,6 +530,7 @@ https://twitter.com/NorbertdeLangen
 ### Gdańsk
 
 <img src="https://pbs.twimg.com/profile_images/910825228175069184/WC_iMm7-_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Kasia Jastrzębska" />
+
 Kasia Jastrzębska  
 Topics: React, Redux, Async, CSS in JS, ClojureScript  
 https://twitter.com/kejt_bw
@@ -466,6 +538,7 @@ https://twitter.com/kejt_bw
 ### Krakow
 
 <img src="https://pbs.twimg.com/profile_images/378800000409145857/2224a7110f583fb0661ca7cfdf01ce76_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Anna Migas" />
+
 Anna Migas  
 Topics: HTML, CSS, JavaScript, Web Animations, Web Performance  
 https://twitter.com/szynszyliszys
@@ -473,6 +546,7 @@ https://twitter.com/szynszyliszys
 ### Poznań
 
 <img src="https://pbs.twimg.com/profile_images/858080114197880833/DXeDmf51_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Tomasz Łakomy" />
+
 Tomasz Łakomy  
 Topics: React, VR, jQuery  
 https://twitter.com/tlakomy
@@ -480,6 +554,7 @@ https://twitter.com/tlakomy
 ### Warsaw
 
 <img src="https://pbs.twimg.com/profile_images/889850940852973568/kqTZlAf5_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Aga Naplocha" />
+
 Aga Naplocha  
 Topics: CSS, Teaching Web Technologies  
 https://twitter.com/aganaplocha
@@ -487,6 +562,7 @@ https://twitter.com/aganaplocha
 ### Wrocław
 
 <img src="https://pbs.twimg.com/profile_images/910449258263916545/l0pbXflE_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Mike Grabowski" />
+
 Mike Grabowski  
 Topics: React Native, JavaScript, Tooling  
 https://twitter.com/grabbou
@@ -496,11 +572,13 @@ https://twitter.com/grabbou
 ### Lisbon
 
 <img src="https://pbs.twimg.com/profile_images/841594344658391043/xh_QO-C9_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Daniela Matos de Carvalho" />
+
 Daniela Matos de Carvalho  
 Topics: HTTP/2, JavaScript, React, Offline First  
 https://twitter.com/sericaia
 
 <img src="https://pbs.twimg.com/profile_images/849780545823195136/afw55D2y_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of David Dias" />
+
 David Dias  
 Topics: IPFS, P2P, JavaScript, Node.js  
 https://twitter.com/daviddias
@@ -508,6 +586,7 @@ https://twitter.com/daviddias
 ### Porto
 
 <img src="https://pbs.twimg.com/profile_images/926881997863211008/WMzMYyCe_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sara Vieira" />
+
 Sara Vieira  
 Topics: Styleguides, React, CSS  
 https://twitter.com/NikkitaFTW
@@ -517,16 +596,19 @@ https://twitter.com/NikkitaFTW
 ### Moscow
 
 <img src="https://pbs.twimg.com/profile_images/486131556675616770/3695qr5w_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Nikita Prokopov" />
+
 Nikita Prokopov  
 Topics: Clojure, DataScript, Rum, FiraCode, AnyBar  
 https://twitter.com/nikitonsky
 
 <img src="https://pbs.twimg.com/profile_images/880419066833510400/xJ1uiJUF_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sergey Rubanov" />
+
 Sergey Rubanov  
 Topics: Standards, Web Assembly  
 https://twitter.com/chicoxyzzy
 
 <img src="http://fpconf.ru/images/sobolev.jpg" height="70px" width="auto" align="left" alt="Headshot of Nikita Sobolev" />
+
 Nikita Sobolev  
 Topics: Elixir, Python  
 https://twitter.com/elixir_lang_mos
@@ -536,11 +618,13 @@ https://twitter.com/elixir_lang_mos
 ### Belgrade
 
 <img src="https://pbs.twimg.com/profile_images/823894615145201664/0xxSg0_c_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Aleksandar Simovic" />
+
 Aleksandar Simovic  
 Topics: Serverless  
 https://twitter.com/simalexan
 
 <img src="https://pbs.twimg.com/profile_images/858708563488845829/bfs-19gk_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Slobodan Stojanović" />
+
 Slobodan Stojanović  
 Topics: Serverless, Offline Web, Chat Bots  
 [https://twitter.com/slobodan_](https://twitter.com/slobodan_)
@@ -550,6 +634,7 @@ Topics: Serverless, Offline Web, Chat Bots
 ### Córdoba
 
 <img src="https://pbs.twimg.com/profile_images/916227643913244672/uR9VcF3B_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Javi Velasco" />
+
 Javi Velasco  
 Topics: React, CSS in JS, React Toolbox  
 https://twitter.com/javivelasco
@@ -557,6 +642,7 @@ https://twitter.com/javivelasco
 ### Santander
 
 <img src="https://pbs.twimg.com/profile_images/1330141226/avatar-500_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Erik Rasmussen" />
+
 Erik Rasmussen  
 Topics: React, Redux, Redux-Form, Forms  
 https://twitter.com/erikras
@@ -566,11 +652,13 @@ https://twitter.com/erikras
 ### Zurich
 
 <img src="https://pbs.twimg.com/profile_images/772017431376175104/XvIsVuB4_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Martin Splitt" />
+
 Martin Splitt  
 Topics: VR, Web Performance  
 https://twitter.com/g33konaut
 
 <img src="https://pbs.twimg.com/profile_images/737308641511002113/YB7CH5CE_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sebastian Siemssen" />
+
 Sebastian Siemssen  
 Topics: React, GraphQL, Tooling  
 https://twitter.com/thefubhy
@@ -580,11 +668,13 @@ https://twitter.com/thefubhy
 ### Kyiv
 
 <img src="https://pbs.twimg.com/profile_images/918401186516160512/aTJN_ydF_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Gregory Shehet" />
+
 Gregory Shehet  
 Topics: Functional Reactive Programming, MobX, CSS in JS, React  
 https://twitter.com/AGambit95
 
 <img src="https://pbs.twimg.com/profile_images/908763932747288576/ySuitABV_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Roman Liutikov" />
+
 Roman Liutikov  
 Topics: ClojureScript, React, Compilers  
 https://twitter.com/roman01la
@@ -594,6 +684,7 @@ https://twitter.com/roman01la
 ### Birmingham
 
 <img src="https://pbs.twimg.com/profile_images/807277326539046912/EZR6qL-S_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Bruce Lawson" />
+
 Bruce Lawson  
 Topics: Standards, Performance  
 https://twitter.com/brucel
@@ -601,11 +692,13 @@ https://twitter.com/brucel
 ### Brighton
 
 <img src="https://pbs.twimg.com/profile_images/727173860764844032/0hGX9DZG_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Jeremy Keith" />
+
 Jeremy Keith  
 Topics: Standards, Web Development, Web Design, CSS, Accessibility  
 https://twitter.com/adactio
 
 <img src="https://pbs.twimg.com/profile_images/526405732330004483/Cq5RGV8S_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Paul Robert Lloyd" />
+
 Paul Robert Lloyd  
 Topics: Design, Web Design, Architecture, Design Systems, Trains  
 https://twitter.com/paulrobertlloyd
@@ -613,11 +706,13 @@ https://twitter.com/paulrobertlloyd
 ### Bristol
 
 <img src="https://pbs.twimg.com/profile_images/781380559947915265/wrjtv_jp_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Rachel Andrew" />
+
 Rachel Andrew  
 Topics: CSS  
 https://twitter.com/rachelandrew
 
 <img src="https://pbs.twimg.com/profile_images/820304800478658562/V20lAtva_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Ruth John" />
+
 Ruth John  
 Topics: CSS Animations  
 https://twitter.com/Rumyra
@@ -625,6 +720,7 @@ https://twitter.com/Rumyra
 ### Leighton Buzzard
 
 <img src="https://pbs.twimg.com/profile_images/528613343381032960/aFnqmqcK_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Caroline Jarrett" />
+
 Caroline Jarrett  
 Topics: Forms Usability, User Research  
 https://twitter.com/cjforms
@@ -632,97 +728,116 @@ https://twitter.com/cjforms
 ### London
 
 <img src="https://pbs.twimg.com/profile_images/925719098042052610/y-llZ0AF_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Ada Rose Cannon" />
+
 Ada Rose Cannon  
 Topics: HTML, CSS, JavaScript, WebVR, Web Technologies, Progressive Web Apps  
 https://twitter.com/lady_ada_king
 
 <img src="https://pbs.twimg.com/profile_images/865146773244858369/YxOo7hIC_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Alessandro Cinelli" />
+
 Alessandro Cinelli  
 Topics: JavaScript  
 https://twitter.com/cirpo
 
 <img src="https://pbs.twimg.com/profile_images/1540939151/whereIsAlexWithGlasses_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Alex Lobera" />
+
 Alex Lobera  
 Topics: JavaScript, React, Redux, GraphQL  
 https://twitter.com/alex_lobera  
 
 <img src="https://pbs.twimg.com/profile_images/920632138013298689/TdWXZUfN_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Alexandra Deschamps-Sonsino" />
+
 Alexandra Deschamps-Sonsino  
 Topics: Internet of Things, Smart Homes, Connected Devices  
 https://twitter.com/iotwatch
 
 <img src="https://pbs.twimg.com/profile_images/518444104854679552/aU3S4Wji_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Alla Kholmatova" />
+
 Alla Kholmatova  
 Topics: Design Systems  
 https://twitter.com/craftui
 
 <img src="https://pbs.twimg.com/profile_images/923316049050783744/HQTS2EsC_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Andrew Betts" />
+
 Andrew Betts  
 Topics: Networks, Performance, Web  
 https://twitter.com/triblondon
 
 <img src="https://pbs.twimg.com/profile_images/829282867020722177/el35E312_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Anna Doubková" />
+
 Anna Doubková  
 Topics: React, Testing  
 https://twitter.com/lithinn
 
 <img src="https://avatars0.githubusercontent.com/u/17880?s=400&v=4" height="70px" width="auto" align="left" alt="Headshot of Bodil Stokke" />
+
 Bodil Stokke  
 Topics: Programming, Functional Programming  
 https://twitter.com/bodil
 
 <img src="https://pbs.twimg.com/profile_images/780901614794178560/XcFiEOAH_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Chris Noring" />
+
 Chris Noring  
 Topics: JS, RXJS, Angular, React  
 https://twitter.com/chris_noring  
 
 <img src="https://pbs.twimg.com/profile_images/818604518820679683/pJd1hqvC_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Cristiano Rastelli" />
+
 Cristiano Rastelli  
 Topics: CSS, CSS in JS  
 https://twitter.com/areaweb
 
 <img src="https://pbs.twimg.com/profile_images/906557353549598720/oapgW_Fp_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Dan Abramov" />
+
 Dan Abramov  
 Topics: JavaScript, React, Redux, Tooling  
 https://twitter.com/dan_abramov
 
 <img src="https://pbs.twimg.com/profile_images/880760574501679105/i_iXmIbn_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Davide 'Folletto' Casali" />
+
 Davide 'Folletto' Casali  
 Topics: Design, User Experience, Management, Leadership, Startup  
 https://twitter.com/Folletto
 
 <img src="https://pbs.twimg.com/profile_images/796861611030024192/pVl1eq7f_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Gerard Sans" />
+
 Gerard Sans  
 Topics: Angular, React, GraphQL, CSS Animations, RxJS  
 https://twitter.com/gerardsans
 
 <img src="https://pbs.twimg.com/profile_images/875454858215780352/etiz5li-_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Gojko Adzic" />
+
 Gojko Adzic  
 Topics: Testing, Requirements, Serverless  
 https://twitter.com/gojkoadzic
 
 <img src="https://pbs.twimg.com/profile_images/736631175985434624/yYKH74aG_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Michele Bertoli" />
+
 Michele Bertoli  
 Topics: React, Testing  
 https://twitter.com/MicheleBertoli
 
 <img src="https://pbs.twimg.com/profile_images/755148129968787457/iQ16fdT9_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Phil Plückthun" />
+
 Phil Plückthun  
 Topics: React, CSS in JS  
 https://twitter.com/_philpl
 
 <img src="https://pbs.twimg.com/profile_images/848590650349989888/6-cAgkjO_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sani Yusuf" />
+
 Sani Yusuf  
 Topics: Ionic, Angular, JS, PWA  
 https://twitter.com/saniyusuf  
 
 <img src="https://pbs.twimg.com/profile_images/752636760245534720/aWQ8XKJD_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sebastian Witalec" />
+
 Sebastian Witalec  
 Topics: NativeScript, Angular, BOTS, JS  
 https://twitter.com/sebawita  
 
 
 <img src="https://pbs.twimg.com/profile_images/684731880923639808/4nBLZm9n_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Inayaili de León" />
+
 Inayaili de León  
 Topics: Design Systems, Responsive Web Design, Design Leadership, UI  
 https://twitter.com/yaili
@@ -730,6 +845,7 @@ https://twitter.com/yaili
 ## Norwich
 
 <img src="https://pbs.twimg.com/profile_images/915986359529111552/G2I0qF5G_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Heydon Pickering" />
+
 Heydon Pickering  
 Topics: Accessibility, Performance, Web  
 https://twitter.com/heydonworks
@@ -741,6 +857,7 @@ https://twitter.com/heydonworks
 ### Ottawa
 
 <img src="https://pbs.twimg.com/profile_images/920685564176846848/qI6wBevB_400x400.jpg" height="70px" width="auto" align="left"" alt="Headshot of Tanya Janca" />
+
 Tanya Janca  
 Topics: InfoSec, Web App Security  
 https://twitter.com/shehackspurple
@@ -748,11 +865,13 @@ https://twitter.com/shehackspurple
 ### Toronto
 
 <img src="https://pbs.twimg.com/profile_images/912036800960405509/PU-_d_C2_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Brenna O'Brien" />
+
 Brenna O'Brien  
 Topics: Motivation, Psychology, Developer Culture, Public Speaking  
 https://twitter.com/brnnbrn
 
 <img src="https://pbs.twimg.com/profile_images/646718876395311104/VxpVI-O6_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Tiff Nogueira" />
+
 Tiff Nogueira   
 Topics: CSS Grids, React, Redux, Firebase, Flexbox   
 https://twitter.com/tiffcodes
@@ -762,11 +881,13 @@ https://twitter.com/tiffcodes
 ### Boston
 
 <img src="https://pbs.twimg.com/profile_images/832031365071773696/kDchWPLv_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Gleb Bahmutov" />
+
 Gleb Bahmutov  
 Topics: Computer Science, JavaScript, Reactive Programming  
 https://twitter.com/bahmutov &bull; https://slides.com/bahmutov &bull; https://glebbahmutov.com/videos
 
 <img src="https://pbs.twimg.com/profile_images/584963092120899586/TxkxQ7Y5_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Lea Verou" />
+
 Lea Verou  
 Topics: CSS, HTML  
 https://twitter.com/leaverou
@@ -774,6 +895,7 @@ https://twitter.com/leaverou
 ### Carlsbad
 
 <img src="https://pbs.twimg.com/profile_images/902276500107362304/vju-WV1i_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Michael Jackson" />
+
 Michael Jackson  
 Topics: React, JavaScript, React Router  
 https://twitter.com/mjackson
@@ -781,6 +903,7 @@ https://twitter.com/mjackson
 ### Cincinnati
 
 <img src="https://pbs.twimg.com/profile_images/817391213183717376/EtDzr5sO_400x400.jpg" height="70px" width="auto" align="left"" alt="Headshot of Carin Meier" />
+
 Carin Meier  
 Topics: Clojure, Machine Learning, Programming  
 https://twitter.com/gigasquid
@@ -788,6 +911,7 @@ https://twitter.com/gigasquid
 ### Denver
 
 <img src="https://pbs.twimg.com/profile_images/923079722778505216/qhL5tFpp_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Miriam Suzanne" />
+
 Miriam Suzanne  
 Topics: CSS, Sass, Architecture, Design Systems  
 https://twitter.com/mirisuzanne
@@ -795,6 +919,7 @@ https://twitter.com/mirisuzanne
 ### Midwest
 
 <img src="https://pbs.twimg.com/profile_images/873189682242367489/ereVA7Ub_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Levi Bostian" />
+
 Levi Bostian  
 Topics: Android, RxJava, Kotlin, Freelancing, Swift, iOS, Productivity, Startups, Bootstrapping
 https://twitter.com/levibostian
@@ -802,6 +927,7 @@ https://twitter.com/levibostian
 ### Nashville
 
 <img src="https://pbs.twimg.com/profile_images/899001646679814145/4TU9HfO-_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Aimee Knight" />
+
 Aimee Knight  
 Topics: JavaScript, CSS, Angular, Growing Junior Developers  
 https://twitter.com/Aimee_Knight
@@ -809,6 +935,7 @@ https://twitter.com/Aimee_Knight
 ### New Jersey
 
 <img src="https://pbs.twimg.com/profile_images/918655507698679808/B8xrPFCs_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Ken Wheeler" />
+
 Ken Wheeler  
 Topics: React, React Native, ReasonML  
 https://twitter.com/ken_wheeler
@@ -816,11 +943,13 @@ https://twitter.com/ken_wheeler
 ### New Orleans
 
 <img src="https://pbs.twimg.com/profile_images/417667937105752064/Z6SeM2_a_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Gant Laborde" />
+
 Gant Laborde  
 Topics:  JavaScript, React Native, Leadership, Redux, Open Source, Tooling, Public Speaking  
 https://twitter.com/GantLaborde
 
 <img src="https://pbs.twimg.com/profile_images/861717239002562560/r01NX6n0_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sia Karamalegos" />
+
 Sia Karamalegos  
 Topics: React, JavaScript, React Native, Front-End Performance  
 https://twitter.com/thegreengreek
@@ -828,46 +957,55 @@ https://twitter.com/thegreengreek
 ### New York
 
 <img src="https://pbs.twimg.com/profile_images/62572418/me_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of David Nolen" />
+
 David Nolen  
 Topics: Clojure, ClojureScript, Om, Functional Programming, Computer Science  
 https://twitter.com/swannodette
 
 <img src="https://pbs.twimg.com/profile_images/412413402749743107/jOnza-Eg_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Diana Mounter" />
+
 Diana Mounter  
 Topics: Design Systems, CSS, Product Design  
 https://twitter.com/broccolini
 
 <img src="https://pbs.twimg.com/profile_images/432754023385403393/6lc-7Xqg_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Henry Zhu" />
+
 Henry Zhu  
 Topics: Open Source, Babel  
 https://twitter.com/left_pad
 
 <img src="https://pbs.twimg.com/profile_images/765902179660161024/zCC2yj_R_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Jen Simmons" />
+
 Jen Simmons  
 Topics: CSS, HTML, Web  
 https://twitter.com/jensimmons
 
 <img src="https://pbs.twimg.com/profile_images/849322587909967874/pOMAg5VX_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Lara Hogan" />
+
 Lara Hogan  
 Topics: Design, Performance, Engineering Management, Public Speaking  
 https://twitter.com/lara_hogan
 
 <img src="https://pbs.twimg.com/profile_images/896883376954757120/gXtYevrr_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Kurtis Kemple" />
+
 Kurtis Kemple  
 Topics: React, React Native, GraphQL, Universal Components  
 https://twitter.com/kurtiskemple
 
 <img src="https://pbs.twimg.com/profile_images/593793041816629248/yKbOT56n_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Mariko Kosaka" />
+
 Mariko Kosaka  
 Topics: HTML, CSS, JavaScript, Web  
 https://twitter.com/kosamari
 
 <img src="https://pbs.twimg.com/profile_images/783341508820893696/JphRM0xk_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Peggy Rayzis" />
+
 Peggy Rayzis  
 Topics: React, React Native, GraphQL  
 https://twitter.com/peggyrayzis
 
 <img src="https://pbs.twimg.com/profile_images/923332236799291393/JFc4MauF_400x400.jpg" height="70px" width="auto" align="left"" alt="Headshot of Una Kravets" />
+
 Una Kravets  
 Topics: CSS, Web  
 https://twitter.com/una
@@ -875,11 +1013,13 @@ https://twitter.com/una
 ### Philadelphia
 
 <img src="https://pbs.twimg.com/profile_images/462071677317160960/fvsOcwr1_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Lis Pardi" />
+
 Lis Pardi  
 Topics: Web  
 https://twitter.com/lispardi
 
 <img src="https://pbs.twimg.com/profile_images/635812303342956545/Fo4RyEgH_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Richard Feldman" />
+
 Richard Feldman  
 Topics: Elm  
 https://twitter.com/rtfeldman
@@ -887,11 +1027,13 @@ https://twitter.com/rtfeldman
 ### Pittsburgh
 
 <img src="https://pbs.twimg.com/profile_images/907811115459125248/i8AzK6gR_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Brad Frost" />
+
 Brad Frost  
 Topics: Web Design, Atomic Design, Web Development  
 https://twitter.com/brad_frost
 
 <img src="https://pbs.twimg.com/profile_images/497876628651782146/hrCHz_ym_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Lin Clark" />
+
 Lin Clark  
 Topics: React, WebAssembly, Browsers Internals  
 https://twitter.com/linclark
@@ -899,11 +1041,13 @@ https://twitter.com/linclark
 ### Portland
 
 <img src="https://pbs.twimg.com/profile_images/786039150667411456/t_0mWTZk_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Kyle Shevlin" />
+
 Kyle Shevlin  
 Topics: React, Redux, JavaScript  
 https://twitter.com/kyleshevlin
 
 <img src="https://pbs.twimg.com/profile_images/684146011564933120/eUohVcRB_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Micah Godbolt" />
+
 Micah Godbolt  
 Topics: Front-End Architecture, CSS, Design Systems  
 https://twitter.com/micahgodbolt
@@ -911,6 +1055,7 @@ https://twitter.com/micahgodbolt
 ### Salt Lake City
 
 <img src="https://pbs.twimg.com/profile_images/759557613445001216/6M2E1l4q_400x400.jpg" height="70px" width="auto" align="left"" alt="Headshot of Kent C. Dodds" />
+
 Kent C. Dodds  
 Topics: OSS, React, Testing  
 https://twitter.com/kentcdodds
@@ -918,86 +1063,103 @@ https://twitter.com/kentcdodds
 ### San Francisco
 
 <img src="https://pbs.twimg.com/profile_images/657238456280731648/YvIabjlq_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Anjana Vakil" />
+
 Anjana Vakil  
 Topics: Programming Language Paradigms, Functional Programming (with JavaScript)  
 https://twitter.com/AnjanaVakil
 
 <img src="https://pbs.twimg.com/profile_images/745127659340861440/qKoNl3zu_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Beth Dean" />
+
 Beth Dean  
 Topics: Design, Illustration  
 https://twitter.com/bethdean
 
 <img src="https://pbs.twimg.com/profile_images/773213042477637632/Nc8d6VZg_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Adam Menges" />
+
 Adam Menges  
 Topics: Artificial Intelligence, Design, Computer Science  
 https://twitter.com/adammenges &bull; https://instagram.com/adammenges
 
 <img src="https://pbs.twimg.com/profile_images/880565020173717504/CqM1jdvu_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Boris Cherny" />
+
 Boris Cherny  
 Topics: TypeScript, React, Computer Science  
 https://twitter.com/bcherny
 
 <img src="https://pbs.twimg.com/profile_images/451517791091167232/ycYsDdzq_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Brynn Evans" />
+
 Brynn Evans  
 Topics: Design, Management  
 https://twitter.com/brynn
 
 <img src="https://pbs.twimg.com/profile_images/744899510/avatar_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Estelle Weyl" />
+
 Estelle Weyl  
 Topics: CSS, Performance, Responsive Web Design  
 https://twitter.com/standardista
 
 <img src="https://pbs.twimg.com/profile_images/491609678539792384/YskBOQeH_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Jafar Husain" />
+
 Jafar Husain  
 Topics: JavaScript, ES7, Observables, Reactive Programming, Falcor  
 https://twitter.com/jhusain
 
 <img src="https://pbs.twimg.com/profile_images/922512926711332864/qAY-xrsm_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Jon Gold" />
+
 Jon Gold  
 Topics: Design, Design Systems, React, Artificial Intelligence  
 https://twitter.com/jongold
 
 <img src="https://avatars1.githubusercontent.com/u/12424987?s=460&v=4" height="70px" width="auto" align="left" alt="Headshot of Lisa Huang" />
+
 Lisa Huang  
 Topics: AMP, Offline-First Mobile Apps, React  
 https://twitter.com/lisaychuang
 
 <img src="https://pbs.twimg.com/profile_images/767888976166268928/Ieds3b1K_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Mike Matas" />
+
 Mike Matas  
 Topics: Human Interface Design  
 https://twitter.com/mike_matas &bull; https://instagram.com/mike_matas
 
 <img src="https://pbs.twimg.com/profile_images/818997879696195584/1_vmf7bc_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Mina Markham" />
+
 Mina Markham  
 Topics: CSS Architecture, Sass, Community, Design Systems  
 https://twitter.com/MinaMarkham
 
 <img src="https://pbs.twimg.com/profile_images/779808817785675776/Hf9AwdFs_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Monica Dinculescu" />
+
 Monica Dinculescu  
 Topics: Web Components, Polymer, Emoji  
 https://twitter.com/notwaldorf
 
 <img src="https://pbs.twimg.com/profile_images/865264595195265024/EuTAyJFJ_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Preethi Kasireddy" />
+
 Preethi Kasireddy  
 Topics: Machine Learning, Natural Language Processing, React  
 https://twitter.com/iam_preethi
 
 <img src="https://pbs.twimg.com/profile_images/856249108885110784/97cssCek_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sarah Drasner" />
+
 Sarah Drasner  
 Topics: CSS, SVG, Animations, Vue.js, React  
 https://twitter.com/sarah_edo
 
 <img src="https://pbs.twimg.com/profile_images/913444398133735427/7zjUK6pp_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sean Grove" />
+
 Sean Grove  
 Topics: GraphQL, ReasonML, OCaml  
 https://twitter.com/sgrove
 
 <img src="https://pbs.twimg.com/profile_images/847556940028923905/xlh3pLCr_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Stephanie Rewis" />
+
 Stephanie Rewis  
 Topics: Design Systems, CSS  
 https://twitter.com/stefsull
 
 <img src="https://pbs.twimg.com/profile_images/821783522427834369/SOIW4xGP_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Tracy Lee" />
+
 Tracy Lee  
 Topics: Reactive Programming, Angular, Ember.js  
 https://twitter.com/ladyleet
@@ -1009,6 +1171,7 @@ https://twitter.com/ladyleet
 ### Buenos Aires
 
 <img src="https://pbs.twimg.com/profile_images/540127281490845697/_2zxxUOt_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Evangelina Ferreira" />
+
 Evangelina Ferreira   
 Topics: CSS, Animations   
 https://twitter.com/evaferreira92
@@ -1018,6 +1181,7 @@ https://twitter.com/evaferreira92
 ### Belo Horizonte
 
 <img src="https://pbs.twimg.com/profile_images/880632277188972544/iHbGo43-_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Beto Muniz" />
+
 Beto Muniz  
 Topics: React, JavaScript, PWA, Polymer, Community  
 https://twitter.com/obetomuniz
@@ -1025,6 +1189,7 @@ https://twitter.com/obetomuniz
 ### Curitiba
 
 <img src="https://pbs.twimg.com/profile_images/824222313470169088/Te_e1i1f_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Fernando Daciuk" />
+
 Fernando Daciuk  
 Topics: React, JavaScript  
 https://twitter.com/fdaciuk

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Please add to the list and help make the community better connected and richer.
 # Africa
 
 ## Nigeria 🇳🇬
-<img src="https://pbs.twimg.com/profile_images/911164658047963136/SLtLXQQp_400x400.jpg" height="70px" width="auto" align="left" />
+
+<img src="https://pbs.twimg.com/profile_images/911164658047963136/SLtLXQQp_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Ire Aderinokun" />
 Ire Aderinokun  
 Topics: PWA, CSS, Standards  
 https://twitter.com/ireaderinokun   
@@ -21,41 +22,41 @@ https://twitter.com/ireaderinokun
 
 ### Bangalore
 
-<img src="https://avatars3.githubusercontent.com/u/1382793?s=460&v=4" height="70px" width="auto" align="left" />
+<img src="https://avatars3.githubusercontent.com/u/1382793?s=460&v=4" height="70px" width="auto" align="left" alt="Headshot of Ashrith Kulai" />
 Ashrith Kulai  
 Topics: PWA, Polymer, Web Components, Web Performance, Build Tools  
 https://twitter.com/ashrith_kulai  
 
-<img src="https://i.imgur.com/OXCWwy7.jpg" height="70px" width="auto" align="left" />
+<img src="https://i.imgur.com/OXCWwy7.jpg" height="70px" width="auto" align="left" alt="Headshot of Kumar Anirudha" />
 Kumar Anirudha  
 Topics: Python, Node.js, Blockchain, Architecture, Cryptocurrency  
 https://twitter.com/kranirudha
 
-<img src="https://pbs.twimg.com/profile_images/895583823202668544/kFsLGKC3_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/895583823202668544/kFsLGKC3_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Siddharth Kshetrapal" />
 Siddharth Kshetrapal  
 Topics: CSS, Web Performance, React, CSS in JS, Node, Testing  
 https://twitter.com/siddharthkp
 
 ### Mumbai
 
-<img src="https://pbs.twimg.com/profile_images/856209876732739585/rQcsMvCa_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/856209876732739585/rQcsMvCa_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Manjula Dube" />
 Manjula Dube  
 Topics: JavaScript, React, PWA, Node, Testing  
 https://twitter.com/manjula_dube
 
-<img src="https://pbs.twimg.com/profile_images/890131426217259008/6LEkT3eS_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/890131426217259008/6LEkT3eS_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Neehar Venugopal" />
 Neehar Venugopal  
 Topics: Code Splitting, Standards  
 https://twitter.com/neeharv
 
-<img src="https://pbs.twimg.com/profile_images/907656585752842250/PwI99gBG_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/907656585752842250/PwI99gBG_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sidhartha Chatterjee" />
 Sidhartha Chatterjee  
 Topics: React, PWA, Web Performance  
 https://twitter.com/chatsidhartha
 
 ### New Delhi
 
-<img src="https://pbs.twimg.com/profile_images/514383461583294464/bIXQJcyG_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/514383461583294464/bIXQJcyG_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Arun Michael Dsouza" />
 Arun Michael Dsouza  
 Topics: webpack, React, ES6, Tooling, CSS  
 https://twitter.com/amdsouza92
@@ -64,7 +65,7 @@ https://twitter.com/amdsouza92
 
 ### Tyre
 
-<img src="https://pbs.twimg.com/profile_images/903537944320987136/wB28L8qd_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/903537944320987136/wB28L8qd_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sara Soueidan" />
 Sara Soueidan  
 Topics: Animations, CSS, SVG  
 https://twitter.com/sarasoueidan
@@ -73,17 +74,17 @@ https://twitter.com/sarasoueidan
 
 ### Singapore
 
-<img src="https://pbs.twimg.com/profile_images/535685345472286720/9gjiNZiF_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/535685345472286720/9gjiNZiF_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Aysha Anggraini" />
 Aysha Anggraini  
 Topics: CSS, Animations  
 https://twitter.com/renettarenula
 
-<img src="https://pbs.twimg.com/profile_images/917359648524558336/Zu2sC6Jk_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/917359648524558336/Zu2sC6Jk_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Chen Hui Jing" />
 Chen Hui Jing  
 Topics: CSS  
 https://twitter.com/hj_chen
 
-<img src="https://pbs.twimg.com/profile_images/791843247312154625/UsLdWIIj_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/791843247312154625/UsLdWIIj_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Zell Liew" />
 Zell Liew  
 Topics: CSS, JavaScript  
 https://twitter.com/zellwk
@@ -94,22 +95,22 @@ https://twitter.com/zellwk
 
 ### Melbourne
 
-<img src="https://pbs.twimg.com/profile_images/683874690293612545/kDStZOBp_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/683874690293612545/kDStZOBp_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Glen Maddern" />
 Glen Maddern  
 Topics: CSS, Styled Components, React, JavaScript  
 https://twitter.com/glenmaddern
 
-<img src="https://pbs.twimg.com/profile_images/898083700818169856/prj-so7C_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/898083700818169856/prj-so7C_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Karolina Szczur" />
 Karolina Szczur  
 Topics: CSS, HTML, Web, Inclusivity, Diversity  
 https://twitter.com/fox
 
-<img src="https://pbs.twimg.com/profile_images/754886061872979968/BzaOWhs1_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/754886061872979968/BzaOWhs1_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Mark Dalgleish" />
 Mark Dalgleish  
 Topics: Design Systems, Web Design  
 https://twitter.com/markdalgleish
 
-<img src="https://pbs.twimg.com/profile_images/789522857936220160/6OIm0gj0_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/789522857936220160/6OIm0gj0_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Phil Nash" />
 Phil Nash  
 Topics: JavaScript, Web Development, Progressive Web Apps  
 https://twitter.com/philnash
@@ -120,92 +121,91 @@ https://twitter.com/philnash
 
 ### Linz
 
-<img src="https://pbs.twimg.com/profile_images/572642811029426177/GxgFcPtm_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/572642811029426177/GxgFcPtm_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Stefan Baumgartner" />
 Stefan Baumgartner  
 Topics: Web Ops, JavaScript, CSS, Tooling  
 https://twitter.com/ddprrt
 
 ### Salzburg
 
-<img src="https://pbs.twimg.com/profile_images/861132772366331905/4xts32Lq_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/861132772366331905/4xts32Lq_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Lisi Linhart" />
 Lisi Linhart  
 Topics: CSS, Web Animations  
 https://twitter.com/lisi_linhart
 
 ### Vienna
 
-<img src="https://pbs.twimg.com/profile_images/1492139238/profile_pic.jpg_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/1492139238/profile_pic.jpg_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Ali Sharif" />
 Ali Sharif  
 Topics: Functional Programming, Agile, Product Development  
 https://twitter.com/sharifsbeat
 
-<img src="https://pbs.twimg.com/profile_images/678903331176214528/TQTdqGwD_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/678903331176214528/TQTdqGwD_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Andrey Okonetchnikov" />
 Andrey Okonetchnikov  
 Topics: CSS in JS, Linting, Tooling  
 https://twitter.com/okonetchnikov
 
-<img src="https://pbs.twimg.com/profile_images/831514456828026880/IeSbt2Nw_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/831514456828026880/IeSbt2Nw_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Christoph Rumpel" />
 Christoph Rumpel  
 Topics: PHP, Laravel, Chatbots  
 https://twitter.com/christophrumpel
 
-<img src="https://pbs.twimg.com/profile_images/708910026245738496/CUhZSMYO_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/708910026245738496/CUhZSMYO_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Eva Lettner" />
 Eva Lettner  
 Topics: CSS, Web  
 https://twitter.com/eva_trostlos
 
-<img src="https://pbs.twimg.com/profile_images/687205014348103680/ZcIXYv4g_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/687205014348103680/ZcIXYv4g_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Glenn Reyes" />
 Glenn Reyes  
 Topics: Code splitting, React  
 https://twitter.com/glnnrys
 
-<img src="https://pbs.twimg.com/profile_images/875719105839603712/_nJ_XRw1_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/875719105839603712/_nJ_XRw1_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Jan Hruby" />
 Jan Hruby  
 Topics: React, Redux, CSS in JS, (React Native, Serverless, GraphQL)  
 https://twitter.com/mrozilla  
 
-<img src="https://pbs.twimg.com/profile_images/883661923107180544/OpPpk-Ku_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/883661923107180544/OpPpk-Ku_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Juho Vepsäläinen" />
 Juho Vepsäläinen  
 Topics: 3D graphics, Business, React, webpack, Writing  
 https://twitter.com/bebraw
 
-<img alt="Manuel Matuzović" src="https://pbs.twimg.com/profile_images/707504523678523392/Uasvv2C4_400x400.jpg" height="70" align="left">  
-
+<img alt="Headshot of Manuel Matuzović" src="https://pbs.twimg.com/profile_images/707504523678523392/Uasvv2C4_400x400.jpg" height="70" align="left"" alt="Headshot of Manuel Matuzović" />
 Manuel Matuzović  
 Topics: CSS, Accesibility  
 https://twitter.com/mmatuzo  
 
-<img src="https://pbs.twimg.com/profile_images/827473632351879169/ZnoB7yTR_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/827473632351879169/ZnoB7yTR_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Max Böck" />
 Max Böck  
 Topics: CSS, JavaScript, Progressive Web Apps  
 https://twitter.com/mxbck
 
-<img src="https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Max Stoiber" />
 Max Stoiber  
 Topics: React, Styled Components, OSS  
 https://twitter.com/mxstbr
 
-<img src="https://pbs.twimg.com/profile_images/814140031237496832/G-OShJRF_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/814140031237496832/G-OShJRF_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Nik Graf" />
 Nik Graf  
 Topics: VR, Serverless, React  
 https://twitter.com/nikgraf
 
-<img src="https://pbs.twimg.com/profile_images/506474262278856704/V9E39edd_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/506474262278856704/V9E39edd_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Oliver Schöndorfer" />
 Oliver Schöndorfer  
 Topics: Typography, CSS   
 https://twitter.com/glyphe
 
-<img src="https://pbs.twimg.com/profile_images/923184283367469057/HFTSuBcW_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/923184283367469057/HFTSuBcW_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Patrick Stapfer" />
 Patrick Stapfer  
 Topics: ReasonML, Static Typing, Flow  
 https://twitter.com/ryyppy
 
-<img src="https://pbs.twimg.com/profile_images/868930803425828864/1TWl571x_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/868930803425828864/1TWl571x_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Peter Ferak" />
 Peter Ferak  
 Topics: Functional Programming, Computer Science  
 https://twitter.com/ferakpeter
 
-<img src="https://pbs.twimg.com/profile_images/881236730254434304/JZs8wBHX_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/881236730254434304/JZs8wBHX_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Timo Obereder" />
 Timo Obereder  
 Topics: React, Composition, Android, RXJava, Kotlin  
 https://twitter.com/defuex
@@ -214,7 +214,7 @@ https://twitter.com/defuex
 
 ### Hasselt
 
-<img src="https://pbs.twimg.com/profile_images/785464929948172288/SV_c8q7S_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/785464929948172288/SV_c8q7S_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sam Bellen" />
 Sam Bellen  
 Topics: Web Audio, Browser APIs  
 https://twitter.com/sambego
@@ -223,7 +223,7 @@ https://twitter.com/sambego
 
 ### Sofia
 
-<img src="https://pbs.twimg.com/profile_images/1267189835/rado_color_180_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/1267189835/rado_color_180_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Radoslav Stankov" />
 Radoslav Stankov  
 Topics: React, Redux, Ruby, Testing, GraphQL  
 https://twitter.com/rstankov
@@ -232,17 +232,17 @@ https://twitter.com/rstankov
 
 ### Copenhagen
 
-<img src="https://pbs.twimg.com/profile_images/907970058625875968/7ecTxUP4_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/907970058625875968/7ecTxUP4_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Mathias Buus" />
 Mathias Buus  
 Topics: Peer to Peer, Node.js  
 https://twitter.com/mafintosh
 
-<img src="https://pbs.twimg.com/profile_images/783752447940497408/R8S23hzW_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/783752447940497408/R8S23hzW_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Olga Dmitricenko" />
 Olga Dmitricenko  
 Topics: VR, Web Image Processing  
 https://twitter.com/enthusiasto
 
-<img src="https://pbs.twimg.com/profile_images/824242201655910400/mY7NMaDE_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/824242201655910400/mY7NMaDE_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Tereza Sokol" />
 Tereza Sokol  
 Topics: Elm, Visualizations  
 https://twitter.com/terezk_a
@@ -251,7 +251,7 @@ https://twitter.com/terezk_a
 
 ### Helsinki
 
-<img src="https://pbs.twimg.com/profile_images/914150533820243970/DnBSM3RF_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/914150533820243970/DnBSM3RF_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Varya Stepanova" />
 Varya Stepanova  
 Topics: CSS in JS, Style Guides, Visual Regression Testing  
 https://twitter.com/varya_en
@@ -260,7 +260,7 @@ https://twitter.com/varya_en
 
 ### Strasbourg
 
-<img src="https://pbs.twimg.com/profile_images/805046964077400064/TYMf6IWP_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/805046964077400064/TYMf6IWP_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sven Sauleau" />
 Sven Sauleau    
 Topics: JavaScript (Babel), Artificial Intelligence, Linux, Cloud, Ops, Computer Science    
 https://twitter.com/svensauleau
@@ -269,104 +269,104 @@ https://twitter.com/svensauleau
 
 ### Augsburg
 
-<img src="https://pbs.twimg.com/profile_images/715935523630669824/GJ1Xyp_s_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/715935523630669824/GJ1Xyp_s_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Johannes Ewald" />
 Johannes Ewald  
 Topics: Tooling, Standards, webpack  
 https://twitter.com/Jhnnns
 
 ### Berlin
 
-<img src="https://pbs.twimg.com/profile_images/608674513241427968/ycianjI2_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/608674513241427968/ycianjI2_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Ally Long" />
 Ally Long  
 Topics: CSS, Performance,  
 https://twitter.com/allyelle
 
-<img src="https://pbs.twimg.com/profile_images/770970370409201664/NtuKnExn_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/770970370409201664/NtuKnExn_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Artem Sapegin" />
 Artem Sapegin  
 Topics: Styleguides, UI, CSS  
 https://twitter.com/iamsapegin
 
-<img src="https://pbs.twimg.com/profile_images/894641577557192704/ghN7wHa-_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/894641577557192704/ghN7wHa-_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Charlie Owen" />
 Charlie Owen  
 Topics: CSS, Accessibility  
 https://twitter.com/sonniesedge
 
-<img src="https://pbs.twimg.com/profile_images/881401440098557952/HZzFErcN_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/881401440098557952/HZzFErcN_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Hernán Magrini" />
 Hernán Magrini  
 Topics: Web Performance, Service Workers  
 https://twitter.com/hermagrini
 
-<img src="https://pbs.twimg.com/profile_images/858703912769081345/edLyRpPr_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/858703912769081345/edLyRpPr_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Karl Horky" />
 Karl Horky  
 Topics: Tooling, Standards, (OSS), (Psychology)  
 https://twitter.com/karlhorky
 
-<img src="https://pbs.twimg.com/profile_images/908054663483838464/KFIQs9d3_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/908054663483838464/KFIQs9d3_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Lu Yu" />
 Lu Yu  
 Topics: Graphic Design, Typography, Branding, User Experience  
 https://twitter.com/Lugotype
 
-<img src="https://pbs.twimg.com/profile_images/2687722789/0146561e2d575b3e7104e7e94be62b1c_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/2687722789/0146561e2d575b3e7104e7e94be62b1c_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Natalie Pistunovich" />
 Natalie Pistunovich  
 Topics: Mobile Apps, Go  
 https://twitter.com/nataliepis
 
-<img src="https://pbs.twimg.com/profile_images/754012456368963586/DOwDLy2k_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/754012456368963586/DOwDLy2k_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Oleg Slobodskoi" />
 Oleg Slobodskoi  
 Topics: CSS in JS, React  
 https://twitter.com/oleg008
 
-<img src="https://pbs.twimg.com/profile_images/892332104012484608/_3R1X9CN_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/892332104012484608/_3R1X9CN_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Robin Pokorny" />
 Robin Pokorny  
 Topics: Jest, React, AMP, (Elm)  
 https://twitter.com/robinpokorny
 
-<img src="https://pbs.twimg.com/profile_images/889222391007719424/VZb5oY8a_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/889222391007719424/VZb5oY8a_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Yoshua Wuyts" />
 Yoshua Wuyts  
 Topics: Frameworks, Simplicity, Standards, Libraries  
 https://twitter.com/yoshuawuyts
 
 ### Düsseldorf
 
-<img src="https://pbs.twimg.com/profile_images/768792268983701504/kIRa8QWM_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/768792268983701504/kIRa8QWM_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Joy Clark" />
 Joy Clark  
 Topics: Clojure, Web Apps, Security  
 https://twitter.com/iamjoyclark
 
 ### Freiburg
 
-<img src="https://2016.jsconf.is/71c6f10e201cfb70e77c61a513d62729.jpg" height="70px" width="auto" align="left" />
+<img src="https://2016.jsconf.is/71c6f10e201cfb70e77c61a513d62729.jpg" height="70px" width="auto" align="left" alt="Headshot of Vitaly Friedman" />
 Vitaly Friedman  
 Topics: Web Design, Web Development, Responsive Web Design  
 https://twitter.com/smashingmag
 
 ### Hamburg
 
-<img src="https://pbs.twimg.com/profile_images/2127157281/Martin_Kleppe_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/2127157281/Martin_Kleppe_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Martin Kleppe" />
 Martin Kleppe  
 Topics: Weird JS  
 https://twitter.com/aemkei
 
-<img src="https://pbs.twimg.com/profile_images/530780279162429440/AeXURjRd_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/530780279162429440/AeXURjRd_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Mauricio Palma" />
 Mauricio Palma  
 Topics: CSS, JavaScript  
 https://twitter.com/PalmaSwell
 
 ### Karlsruhe
 
-<img src="https://pbs.twimg.com/profile_images/925825609439301633/8lVHsfdV_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/925825609439301633/8lVHsfdV_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Robin Frischmann" />
 Robin Frischmann  
 Topics: CSS, CSS in JS, React  
 https://twitter.com/rofrischmann
 
 ### Munich
 
-<img src="https://pbs.twimg.com/profile_images/661485440751509505/ZnNN9qes_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/661485440751509505/ZnNN9qes_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Franziska Hinkelmann" />
 Franziska Hinkelmann  
 Topics: Node, V8  
 https://twitter.com/fhinkel
 
-<img src="https://pbs.twimg.com/profile_images/1255767431/kung-fu_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/1255767431/kung-fu_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Mathias Bynens" />
 Mathias Bynens  
 Topics: JavaScript (TC39), V8, Chrome  
 https://twitter.com/mathias
@@ -375,29 +375,29 @@ https://twitter.com/mathias
 
 ### Dublin
 
-<img src="https://pbs.twimg.com/profile_images/775076695049113600/fTuBJGTA_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/775076695049113600/fTuBJGTA_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Ingrid Epure" />
 Ingrid Epure  
 Topics: Security, Psychology  
 https://twitter.com/ingridepure
 
-<img src="https://s.gravatar.com/avatar/55066ecb49b57ff9531581b8343aa4fa?size=140" height="70px" width="auto" align="left" />
+<img src="https://s.gravatar.com/avatar/55066ecb49b57ff9531581b8343aa4fa?size=140" height="70px" width="auto" align="left" alt="Headshot of Serena Fritsch" />
 Serena Fritsch  
 Topics: JavaScript, Ember, Developer Workflows  
 https://twitter.com/serifritsch
 
 ## Israel 🇮🇱
 
-<img src="https://pbs.twimg.com/profile_images/736999006220455938/oczRgifS_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/736999006220455938/oczRgifS_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Nir Galon" />
 Nir Galon  
 Topics: Python, API Star, Open Source, Node.js, Angular  
 https://twitter.com/nirgn975
 
-<img src="https://pbs.twimg.com/profile_images/846618003085111296/mi84SWuu_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/846618003085111296/mi84SWuu_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Nir Kaufman" />
 Nir Kaufman  
 Topics: Angular, Firebase, Redux  
 https://twitter.com/nirkaufman
 
-<img src="https://pbs.twimg.com/profile_images/668125552474062848/pTCvcmC3_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/668125552474062848/pTCvcmC3_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Uri Shaked" />
 Uri Shaked  
 Topics: Web Bluetooth, Web VR, Angular, Internet of Things with JavaScript  
 https://twitter.com/UriShaked
@@ -406,14 +406,14 @@ https://twitter.com/UriShaked
 
 ### Milan
 
-<img src="https://pbs.twimg.com/profile_images/845799912222674945/70ofyabn_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/845799912222674945/70ofyabn_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Maurizio Mangione" />
 Maurizio Mangione  
 Topics: Web Components, Polymer, Progressive Web Apps  
 https://twitter.com/granze
 
 ## Verona
 
-<img src="https://pbs.twimg.com/profile_images/873084382235418625/qckzbrGr_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/873084382235418625/qckzbrGr_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Matteo Ronchi" />
 Matteo Ronchi  
 Topics: React, JavaScript, Flow, Web Architectures, Frontend Ops  
 https://twitter.com/cef62
@@ -422,34 +422,34 @@ https://twitter.com/cef62
 
 ### Amsterdam
 
-<img src="https://pbs.twimg.com/profile_images/905763629701660674/u7wBGyAa_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/905763629701660674/u7wBGyAa_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Alexey Kureev" />
 Alexey Kureev  
 Topics: React Native  
 https://twitter.com/kureevalexey
 
-<img src="https://pbs.twimg.com/profile_images/734378184918073348/j3bsV9Xk_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/734378184918073348/j3bsV9Xk_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Carmen Popoviciu" />
 Carmen Popoviciu  
 Topics: Angular, JavaScript, Machine Learning, Neural Networks, Polymer, Web Components  
 https://twitter.com/carmenpopoviciu
 
-<img src="https://pbs.twimg.com/profile_images/852804703373074432/YVMyqpMW_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/852804703373074432/YVMyqpMW_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Kitze" />
 Kitze  
 Topics: MobX, State Management, GraphQL, CSS in JS  
 https://twitter.com/thekitze
 
-<img src="https://pbs.twimg.com/profile_images/661253444058005504/uO5nbrTL_bigger.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/661253444058005504/uO5nbrTL_bigger.jpg" height="70px" width="auto" align="left" alt="Headshot of Michel Weststrate" />
 Michel Weststrate  
 Topics: MobX, React, mobx-state-tree, Typescript, Open Source  
 https://twitter.com/mweststrate
 
-<img src="https://pbs.twimg.com/profile_images/859482903763460098/565FGTxs_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/859482903763460098/565FGTxs_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Narendra Shetty" />
 Narendra Shetty  
 Topics: React, PWA  
 https://twitter.com/narendra_shetty
 
 ### Zwolle
 
-<img src="https://pbs.twimg.com/profile_images/722165598579507205/l4QzAmu8_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/722165598579507205/l4QzAmu8_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Norbert de Langen" />
 Norbert de Langen  
 Topics: Component Libraries, React, Storybook, Open Source, Communities  
 https://twitter.com/NorbertdeLangen
@@ -458,35 +458,35 @@ https://twitter.com/NorbertdeLangen
 
 ### Gdańsk
 
-<img src="https://pbs.twimg.com/profile_images/910825228175069184/WC_iMm7-_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/910825228175069184/WC_iMm7-_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Kasia Jastrzębska" />
 Kasia Jastrzębska  
 Topics: React, Redux, Async, CSS in JS, ClojureScript  
 https://twitter.com/kejt_bw
 
 ### Krakow
 
-<img src="https://pbs.twimg.com/profile_images/378800000409145857/2224a7110f583fb0661ca7cfdf01ce76_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/378800000409145857/2224a7110f583fb0661ca7cfdf01ce76_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Anna Migas" />
 Anna Migas  
 Topics: HTML, CSS, JavaScript, Web Animations, Web Performance  
 https://twitter.com/szynszyliszys
 
 ### Poznań
 
-<img src="https://pbs.twimg.com/profile_images/858080114197880833/DXeDmf51_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/858080114197880833/DXeDmf51_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Tomasz Łakomy" />
 Tomasz Łakomy  
 Topics: React, VR, jQuery  
 https://twitter.com/tlakomy
 
 ### Warsaw
 
-<img src="https://pbs.twimg.com/profile_images/889850940852973568/kqTZlAf5_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/889850940852973568/kqTZlAf5_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Aga Naplocha" />
 Aga Naplocha  
 Topics: CSS, Teaching Web Technologies  
 https://twitter.com/aganaplocha
 
 ### Wrocław
 
-<img src="https://pbs.twimg.com/profile_images/910449258263916545/l0pbXflE_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/910449258263916545/l0pbXflE_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Mike Grabowski" />
 Mike Grabowski  
 Topics: React Native, JavaScript, Tooling  
 https://twitter.com/grabbou
@@ -495,19 +495,19 @@ https://twitter.com/grabbou
 
 ### Lisbon
 
-<img src="https://pbs.twimg.com/profile_images/841594344658391043/xh_QO-C9_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/841594344658391043/xh_QO-C9_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Daniela Matos de Carvalho" />
 Daniela Matos de Carvalho  
 Topics: HTTP/2, JavaScript, React, Offline First  
 https://twitter.com/sericaia
 
-<img src="https://pbs.twimg.com/profile_images/849780545823195136/afw55D2y_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/849780545823195136/afw55D2y_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of David Dias" />
 David Dias  
 Topics: IPFS, P2P, JavaScript, Node.js  
 https://twitter.com/daviddias
 
 ### Porto
 
-<img src="https://pbs.twimg.com/profile_images/926881997863211008/WMzMYyCe_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/926881997863211008/WMzMYyCe_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sara Vieira" />
 Sara Vieira  
 Topics: Styleguides, React, CSS  
 https://twitter.com/NikkitaFTW
@@ -516,17 +516,17 @@ https://twitter.com/NikkitaFTW
 
 ### Moscow
 
-<img src="https://pbs.twimg.com/profile_images/486131556675616770/3695qr5w_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/486131556675616770/3695qr5w_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Nikita Prokopov" />
 Nikita Prokopov  
 Topics: Clojure, DataScript, Rum, FiraCode, AnyBar  
 https://twitter.com/nikitonsky
 
-<img src="https://pbs.twimg.com/profile_images/880419066833510400/xJ1uiJUF_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/880419066833510400/xJ1uiJUF_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sergey Rubanov" />
 Sergey Rubanov  
 Topics: Standards, Web Assembly  
 https://twitter.com/chicoxyzzy
 
-<img src="http://fpconf.ru/images/sobolev.jpg" height="70px" width="auto" align="left" />
+<img src="http://fpconf.ru/images/sobolev.jpg" height="70px" width="auto" align="left" alt="Headshot of Nikita Sobolev" />
 Nikita Sobolev  
 Topics: Elixir, Python  
 https://twitter.com/elixir_lang_mos
@@ -535,12 +535,12 @@ https://twitter.com/elixir_lang_mos
 
 ### Belgrade
 
-<img src="https://pbs.twimg.com/profile_images/823894615145201664/0xxSg0_c_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/823894615145201664/0xxSg0_c_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Aleksandar Simovic" />
 Aleksandar Simovic  
 Topics: Serverless  
 https://twitter.com/simalexan
 
-<img src="https://pbs.twimg.com/profile_images/858708563488845829/bfs-19gk_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/858708563488845829/bfs-19gk_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Slobodan Stojanović" />
 Slobodan Stojanović  
 Topics: Serverless, Offline Web, Chat Bots  
 [https://twitter.com/slobodan_](https://twitter.com/slobodan_)
@@ -549,14 +549,14 @@ Topics: Serverless, Offline Web, Chat Bots
 
 ### Córdoba
 
-<img src="https://pbs.twimg.com/profile_images/916227643913244672/uR9VcF3B_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/916227643913244672/uR9VcF3B_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Javi Velasco" />
 Javi Velasco  
 Topics: React, CSS in JS, React Toolbox  
 https://twitter.com/javivelasco
 
 ### Santander
 
-<img src="https://pbs.twimg.com/profile_images/1330141226/avatar-500_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/1330141226/avatar-500_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Erik Rasmussen" />
 Erik Rasmussen  
 Topics: React, Redux, Redux-Form, Forms  
 https://twitter.com/erikras
@@ -565,12 +565,12 @@ https://twitter.com/erikras
 
 ### Zurich
 
-<img src="https://pbs.twimg.com/profile_images/772017431376175104/XvIsVuB4_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/772017431376175104/XvIsVuB4_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Martin Splitt" />
 Martin Splitt  
 Topics: VR, Web Performance  
 https://twitter.com/g33konaut
 
-<img src="https://pbs.twimg.com/profile_images/737308641511002113/YB7CH5CE_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/737308641511002113/YB7CH5CE_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sebastian Siemssen" />
 Sebastian Siemssen  
 Topics: React, GraphQL, Tooling  
 https://twitter.com/thefubhy
@@ -579,12 +579,12 @@ https://twitter.com/thefubhy
 
 ### Kyiv
 
-<img src="https://pbs.twimg.com/profile_images/918401186516160512/aTJN_ydF_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/918401186516160512/aTJN_ydF_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Gregory Shehet" />
 Gregory Shehet  
 Topics: Functional Reactive Programming, MobX, CSS in JS, React  
 https://twitter.com/AGambit95
 
-<img src="https://pbs.twimg.com/profile_images/908763932747288576/ySuitABV_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/908763932747288576/ySuitABV_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Roman Liutikov" />
 Roman Liutikov  
 Topics: ClojureScript, React, Compilers  
 https://twitter.com/roman01la
@@ -593,143 +593,143 @@ https://twitter.com/roman01la
 
 ### Birmingham
 
-<img src="https://pbs.twimg.com/profile_images/807277326539046912/EZR6qL-S_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/807277326539046912/EZR6qL-S_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Bruce Lawson" />
 Bruce Lawson  
 Topics: Standards, Performance  
 https://twitter.com/brucel
 
 ### Brighton
 
-<img src="https://pbs.twimg.com/profile_images/727173860764844032/0hGX9DZG_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/727173860764844032/0hGX9DZG_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Jeremy Keith" />
 Jeremy Keith  
 Topics: Standards, Web Development, Web Design, CSS, Accessibility  
 https://twitter.com/adactio
 
-<img src="https://pbs.twimg.com/profile_images/526405732330004483/Cq5RGV8S_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/526405732330004483/Cq5RGV8S_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Paul Robert Lloyd" />
 Paul Robert Lloyd  
 Topics: Design, Web Design, Architecture, Design Systems, Trains  
 https://twitter.com/paulrobertlloyd
 
 ### Bristol
 
-<img src="https://pbs.twimg.com/profile_images/781380559947915265/wrjtv_jp_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/781380559947915265/wrjtv_jp_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Rachel Andrew" />
 Rachel Andrew  
 Topics: CSS  
 https://twitter.com/rachelandrew
 
-<img src="https://pbs.twimg.com/profile_images/820304800478658562/V20lAtva_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/820304800478658562/V20lAtva_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Ruth John" />
 Ruth John  
 Topics: CSS Animations  
 https://twitter.com/Rumyra
 
 ### Leighton Buzzard
 
-<img src="https://pbs.twimg.com/profile_images/528613343381032960/aFnqmqcK_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/528613343381032960/aFnqmqcK_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Caroline Jarrett" />
 Caroline Jarrett  
 Topics: Forms Usability, User Research  
 https://twitter.com/cjforms
 
 ### London
 
-<img src="https://pbs.twimg.com/profile_images/925719098042052610/y-llZ0AF_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/925719098042052610/y-llZ0AF_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Ada Rose Cannon" />
 Ada Rose Cannon  
 Topics: HTML, CSS, JavaScript, WebVR, Web Technologies, Progressive Web Apps  
 https://twitter.com/lady_ada_king
 
-<img src="https://pbs.twimg.com/profile_images/865146773244858369/YxOo7hIC_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/865146773244858369/YxOo7hIC_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Alessandro Cinelli" />
 Alessandro Cinelli  
 Topics: JavaScript  
 https://twitter.com/cirpo
 
-<img src="https://pbs.twimg.com/profile_images/1540939151/whereIsAlexWithGlasses_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/1540939151/whereIsAlexWithGlasses_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Alex Lobera" />
 Alex Lobera  
 Topics: JavaScript, React, Redux, GraphQL  
 https://twitter.com/alex_lobera  
 
-<img src="https://pbs.twimg.com/profile_images/920632138013298689/TdWXZUfN_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/920632138013298689/TdWXZUfN_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Alexandra Deschamps-Sonsino" />
 Alexandra Deschamps-Sonsino  
 Topics: Internet of Things, Smart Homes, Connected Devices  
 https://twitter.com/iotwatch
 
-<img src="https://pbs.twimg.com/profile_images/518444104854679552/aU3S4Wji_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/518444104854679552/aU3S4Wji_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Alla Kholmatova" />
 Alla Kholmatova  
 Topics: Design Systems  
 https://twitter.com/craftui
 
-<img src="https://pbs.twimg.com/profile_images/923316049050783744/HQTS2EsC_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/923316049050783744/HQTS2EsC_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Andrew Betts" />
 Andrew Betts  
 Topics: Networks, Performance, Web  
 https://twitter.com/triblondon
 
-<img src="https://pbs.twimg.com/profile_images/829282867020722177/el35E312_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/829282867020722177/el35E312_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Anna Doubková" />
 Anna Doubková  
 Topics: React, Testing  
 https://twitter.com/lithinn
 
-<img src="https://avatars0.githubusercontent.com/u/17880?s=400&v=4" height="70px" width="auto" align="left" />
+<img src="https://avatars0.githubusercontent.com/u/17880?s=400&v=4" height="70px" width="auto" align="left" alt="Headshot of Bodil Stokke" />
 Bodil Stokke  
 Topics: Programming, Functional Programming  
 https://twitter.com/bodil
 
-<img src="https://pbs.twimg.com/profile_images/780901614794178560/XcFiEOAH_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/780901614794178560/XcFiEOAH_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Chris Noring" />
 Chris Noring  
 Topics: JS, RXJS, Angular, React  
 https://twitter.com/chris_noring  
 
-<img src="https://pbs.twimg.com/profile_images/818604518820679683/pJd1hqvC_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/818604518820679683/pJd1hqvC_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Cristiano Rastelli" />
 Cristiano Rastelli  
 Topics: CSS, CSS in JS  
 https://twitter.com/areaweb
 
-<img src="https://pbs.twimg.com/profile_images/906557353549598720/oapgW_Fp_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/906557353549598720/oapgW_Fp_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Dan Abramov" />
 Dan Abramov  
 Topics: JavaScript, React, Redux, Tooling  
 https://twitter.com/dan_abramov
 
-<img src="https://pbs.twimg.com/profile_images/880760574501679105/i_iXmIbn_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/880760574501679105/i_iXmIbn_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Davide 'Folletto' Casali" />
 Davide 'Folletto' Casali  
 Topics: Design, User Experience, Management, Leadership, Startup  
 https://twitter.com/Folletto
 
-<img src="https://pbs.twimg.com/profile_images/796861611030024192/pVl1eq7f_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/796861611030024192/pVl1eq7f_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Gerard Sans" />
 Gerard Sans  
 Topics: Angular, React, GraphQL, CSS Animations, RxJS  
 https://twitter.com/gerardsans
 
-<img src="https://pbs.twimg.com/profile_images/875454858215780352/etiz5li-_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/875454858215780352/etiz5li-_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Gojko Adzic" />
 Gojko Adzic  
 Topics: Testing, Requirements, Serverless  
 https://twitter.com/gojkoadzic
 
-<img src="https://pbs.twimg.com/profile_images/736631175985434624/yYKH74aG_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/736631175985434624/yYKH74aG_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Michele Bertoli" />
 Michele Bertoli  
 Topics: React, Testing  
 https://twitter.com/MicheleBertoli
 
-<img src="https://pbs.twimg.com/profile_images/755148129968787457/iQ16fdT9_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/755148129968787457/iQ16fdT9_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Phil Plückthun" />
 Phil Plückthun  
 Topics: React, CSS in JS  
 https://twitter.com/_philpl
 
-<img src="https://pbs.twimg.com/profile_images/848590650349989888/6-cAgkjO_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/848590650349989888/6-cAgkjO_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sani Yusuf" />
 Sani Yusuf  
 Topics: Ionic, Angular, JS, PWA  
 https://twitter.com/saniyusuf  
 
-<img src="https://pbs.twimg.com/profile_images/752636760245534720/aWQ8XKJD_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/752636760245534720/aWQ8XKJD_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sebastian Witalec" />
 Sebastian Witalec  
 Topics: NativeScript, Angular, BOTS, JS  
 https://twitter.com/sebawita  
 
 
-<img src="https://pbs.twimg.com/profile_images/684731880923639808/4nBLZm9n_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/684731880923639808/4nBLZm9n_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Inayaili de León" />
 Inayaili de León  
 Topics: Design Systems, Responsive Web Design, Design Leadership, UI  
 https://twitter.com/yaili
 
 ## Norwich
 
-<img src="https://pbs.twimg.com/profile_images/915986359529111552/G2I0qF5G_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/915986359529111552/G2I0qF5G_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Heydon Pickering" />
 Heydon Pickering  
 Topics: Accessibility, Performance, Web  
 https://twitter.com/heydonworks
@@ -740,20 +740,19 @@ https://twitter.com/heydonworks
 
 ### Ottawa
 
-<img src="https://pbs.twimg.com/profile_images/920685564176846848/qI6wBevB_400x400.jpg" height="70px" width="auto" align="left">
-
+<img src="https://pbs.twimg.com/profile_images/920685564176846848/qI6wBevB_400x400.jpg" height="70px" width="auto" align="left"" alt="Headshot of Tanya Janca" />
 Tanya Janca  
 Topics: InfoSec, Web App Security  
 https://twitter.com/shehackspurple
 
 ### Toronto
 
-<img src="https://pbs.twimg.com/profile_images/912036800960405509/PU-_d_C2_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/912036800960405509/PU-_d_C2_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Brenna O'Brien" />
 Brenna O'Brien  
 Topics: Motivation, Psychology, Developer Culture, Public Speaking  
 https://twitter.com/brnnbrn
 
-<img src="https://pbs.twimg.com/profile_images/646718876395311104/VxpVI-O6_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/646718876395311104/VxpVI-O6_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Tiff Nogueira" />
 Tiff Nogueira   
 Topics: CSS Grids, React, Redux, Firebase, Flexbox   
 https://twitter.com/tiffcodes
@@ -762,246 +761,243 @@ https://twitter.com/tiffcodes
 
 ### Boston
 
-<img src="https://pbs.twimg.com/profile_images/832031365071773696/kDchWPLv_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/832031365071773696/kDchWPLv_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Gleb Bahmutov" />
 Gleb Bahmutov  
 Topics: Computer Science, JavaScript, Reactive Programming  
 https://twitter.com/bahmutov &bull; https://slides.com/bahmutov &bull; https://glebbahmutov.com/videos
 
-<img src="https://pbs.twimg.com/profile_images/584963092120899586/TxkxQ7Y5_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/584963092120899586/TxkxQ7Y5_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Lea Verou" />
 Lea Verou  
 Topics: CSS, HTML  
 https://twitter.com/leaverou
 
 ### Carlsbad
 
-<img src="https://pbs.twimg.com/profile_images/902276500107362304/vju-WV1i_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/902276500107362304/vju-WV1i_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Michael Jackson" />
 Michael Jackson  
 Topics: React, JavaScript, React Router  
 https://twitter.com/mjackson
 
 ### Cincinnati
 
-<img src="https://pbs.twimg.com/profile_images/817391213183717376/EtDzr5sO_400x400.jpg" height="70px" width="auto" align="left">
-
+<img src="https://pbs.twimg.com/profile_images/817391213183717376/EtDzr5sO_400x400.jpg" height="70px" width="auto" align="left"" alt="Headshot of Carin Meier" />
 Carin Meier  
 Topics: Clojure, Machine Learning, Programming  
 https://twitter.com/gigasquid
 
 ### Denver
 
-<img src="https://pbs.twimg.com/profile_images/923079722778505216/qhL5tFpp_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/923079722778505216/qhL5tFpp_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Miriam Suzanne" />
 Miriam Suzanne  
 Topics: CSS, Sass, Architecture, Design Systems  
 https://twitter.com/mirisuzanne
 
 ### Midwest
 
-<img src="https://pbs.twimg.com/profile_images/873189682242367489/ereVA7Ub_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/873189682242367489/ereVA7Ub_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Levi Bostian" />
 Levi Bostian  
 Topics: Android, RxJava, Kotlin, Freelancing, Swift, iOS, Productivity, Startups, Bootstrapping
 https://twitter.com/levibostian
 
 ### Nashville
 
-<img src="https://pbs.twimg.com/profile_images/899001646679814145/4TU9HfO-_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/899001646679814145/4TU9HfO-_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Aimee Knight" />
 Aimee Knight  
 Topics: JavaScript, CSS, Angular, Growing Junior Developers  
 https://twitter.com/Aimee_Knight
 
 ### New Jersey
 
-<img src="https://pbs.twimg.com/profile_images/918655507698679808/B8xrPFCs_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/918655507698679808/B8xrPFCs_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Ken Wheeler" />
 Ken Wheeler  
 Topics: React, React Native, ReasonML  
 https://twitter.com/ken_wheeler
 
 ### New Orleans
 
-<img src="https://pbs.twimg.com/profile_images/417667937105752064/Z6SeM2_a_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/417667937105752064/Z6SeM2_a_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Gant Laborde" />
 Gant Laborde  
 Topics:  JavaScript, React Native, Leadership, Redux, Open Source, Tooling, Public Speaking  
 https://twitter.com/GantLaborde
 
-<img src="https://pbs.twimg.com/profile_images/861717239002562560/r01NX6n0_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/861717239002562560/r01NX6n0_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sia Karamalegos" />
 Sia Karamalegos  
 Topics: React, JavaScript, React Native, Front-End Performance  
 https://twitter.com/thegreengreek
 
 ### New York
 
-<img src="https://pbs.twimg.com/profile_images/62572418/me_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/62572418/me_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of David Nolen" />
 David Nolen  
 Topics: Clojure, ClojureScript, Om, Functional Programming, Computer Science  
 https://twitter.com/swannodette
 
-<img src="https://pbs.twimg.com/profile_images/412413402749743107/jOnza-Eg_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/412413402749743107/jOnza-Eg_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Diana Mounter" />
 Diana Mounter  
 Topics: Design Systems, CSS, Product Design  
 https://twitter.com/broccolini
 
-<img src="https://pbs.twimg.com/profile_images/432754023385403393/6lc-7Xqg_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/432754023385403393/6lc-7Xqg_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Henry Zhu" />
 Henry Zhu  
 Topics: Open Source, Babel  
 https://twitter.com/left_pad
 
-<img src="https://pbs.twimg.com/profile_images/765902179660161024/zCC2yj_R_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/765902179660161024/zCC2yj_R_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Jen Simmons" />
 Jen Simmons  
 Topics: CSS, HTML, Web  
 https://twitter.com/jensimmons
 
-<img src="https://pbs.twimg.com/profile_images/849322587909967874/pOMAg5VX_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/849322587909967874/pOMAg5VX_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Lara Hogan" />
 Lara Hogan  
 Topics: Design, Performance, Engineering Management, Public Speaking  
 https://twitter.com/lara_hogan
 
-<img src="https://pbs.twimg.com/profile_images/896883376954757120/gXtYevrr_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/896883376954757120/gXtYevrr_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Kurtis Kemple" />
 Kurtis Kemple  
 Topics: React, React Native, GraphQL, Universal Components  
 https://twitter.com/kurtiskemple
 
-<img src="https://pbs.twimg.com/profile_images/593793041816629248/yKbOT56n_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/593793041816629248/yKbOT56n_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Mariko Kosaka" />
 Mariko Kosaka  
 Topics: HTML, CSS, JavaScript, Web  
 https://twitter.com/kosamari
 
-<img src="https://pbs.twimg.com/profile_images/783341508820893696/JphRM0xk_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/783341508820893696/JphRM0xk_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Peggy Rayzis" />
 Peggy Rayzis  
 Topics: React, React Native, GraphQL  
 https://twitter.com/peggyrayzis
 
-<img src="https://pbs.twimg.com/profile_images/923332236799291393/JFc4MauF_400x400.jpg" height="70px" width="auto" align="left">
-
+<img src="https://pbs.twimg.com/profile_images/923332236799291393/JFc4MauF_400x400.jpg" height="70px" width="auto" align="left"" alt="Headshot of Una Kravets" />
 Una Kravets  
 Topics: CSS, Web  
 https://twitter.com/una
 
 ### Philadelphia
 
-<img src="https://pbs.twimg.com/profile_images/462071677317160960/fvsOcwr1_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/462071677317160960/fvsOcwr1_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Lis Pardi" />
 Lis Pardi  
 Topics: Web  
 https://twitter.com/lispardi
 
-<img src="https://pbs.twimg.com/profile_images/635812303342956545/Fo4RyEgH_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/635812303342956545/Fo4RyEgH_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Richard Feldman" />
 Richard Feldman  
 Topics: Elm  
 https://twitter.com/rtfeldman
 
 ### Pittsburgh
 
-<img src="https://pbs.twimg.com/profile_images/907811115459125248/i8AzK6gR_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/907811115459125248/i8AzK6gR_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Brad Frost" />
 Brad Frost  
 Topics: Web Design, Atomic Design, Web Development  
 https://twitter.com/brad_frost
 
-<img src="https://pbs.twimg.com/profile_images/497876628651782146/hrCHz_ym_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/497876628651782146/hrCHz_ym_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Lin Clark" />
 Lin Clark  
 Topics: React, WebAssembly, Browsers Internals  
 https://twitter.com/linclark
 
 ### Portland
 
-<img src="https://pbs.twimg.com/profile_images/786039150667411456/t_0mWTZk_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/786039150667411456/t_0mWTZk_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Kyle Shevlin" />
 Kyle Shevlin  
 Topics: React, Redux, JavaScript  
 https://twitter.com/kyleshevlin
 
-<img src="https://pbs.twimg.com/profile_images/684146011564933120/eUohVcRB_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/684146011564933120/eUohVcRB_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Micah Godbolt" />
 Micah Godbolt  
 Topics: Front-End Architecture, CSS, Design Systems  
 https://twitter.com/micahgodbolt
 
 ### Salt Lake City
 
-<img src="https://pbs.twimg.com/profile_images/759557613445001216/6M2E1l4q_400x400.jpg" height="70px" width="auto" align="left">
-
+<img src="https://pbs.twimg.com/profile_images/759557613445001216/6M2E1l4q_400x400.jpg" height="70px" width="auto" align="left"" alt="Headshot of Kent C. Dodds" />
 Kent C. Dodds  
 Topics: OSS, React, Testing  
 https://twitter.com/kentcdodds
 
 ### San Francisco
 
-<img src="https://pbs.twimg.com/profile_images/657238456280731648/YvIabjlq_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/657238456280731648/YvIabjlq_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Anjana Vakil" />
 Anjana Vakil  
 Topics: Programming Language Paradigms, Functional Programming (with JavaScript)  
 https://twitter.com/AnjanaVakil
 
-<img src="https://pbs.twimg.com/profile_images/745127659340861440/qKoNl3zu_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/745127659340861440/qKoNl3zu_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Beth Dean" />
 Beth Dean  
 Topics: Design, Illustration  
 https://twitter.com/bethdean
 
-<img src="https://pbs.twimg.com/profile_images/773213042477637632/Nc8d6VZg_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/773213042477637632/Nc8d6VZg_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Adam Menges" />
 Adam Menges  
 Topics: Artificial Intelligence, Design, Computer Science  
 https://twitter.com/adammenges &bull; https://instagram.com/adammenges
 
-<img src="https://pbs.twimg.com/profile_images/880565020173717504/CqM1jdvu_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/880565020173717504/CqM1jdvu_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Boris Cherny" />
 Boris Cherny  
 Topics: TypeScript, React, Computer Science  
 https://twitter.com/bcherny
 
-<img src="https://pbs.twimg.com/profile_images/451517791091167232/ycYsDdzq_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/451517791091167232/ycYsDdzq_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Brynn Evans" />
 Brynn Evans  
 Topics: Design, Management  
 https://twitter.com/brynn
 
-<img src="https://pbs.twimg.com/profile_images/744899510/avatar_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/744899510/avatar_400x400.png" height="70px" width="auto" align="left" alt="Headshot of Estelle Weyl" />
 Estelle Weyl  
 Topics: CSS, Performance, Responsive Web Design  
 https://twitter.com/standardista
 
-<img src="https://pbs.twimg.com/profile_images/491609678539792384/YskBOQeH_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/491609678539792384/YskBOQeH_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Jafar Husain" />
 Jafar Husain  
 Topics: JavaScript, ES7, Observables, Reactive Programming, Falcor  
 https://twitter.com/jhusain
 
-<img src="https://pbs.twimg.com/profile_images/922512926711332864/qAY-xrsm_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/922512926711332864/qAY-xrsm_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Jon Gold" />
 Jon Gold  
 Topics: Design, Design Systems, React, Artificial Intelligence  
 https://twitter.com/jongold
 
-<img src="https://avatars1.githubusercontent.com/u/12424987?s=460&v=4" height="70px" width="auto" align="left" />
+<img src="https://avatars1.githubusercontent.com/u/12424987?s=460&v=4" height="70px" width="auto" align="left" alt="Headshot of Lisa Huang" />
 Lisa Huang  
 Topics: AMP, Offline-First Mobile Apps, React  
 https://twitter.com/lisaychuang
 
-<img src="https://pbs.twimg.com/profile_images/767888976166268928/Ieds3b1K_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/767888976166268928/Ieds3b1K_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Mike Matas" />
 Mike Matas  
 Topics: Human Interface Design  
 https://twitter.com/mike_matas &bull; https://instagram.com/mike_matas
 
-<img src="https://pbs.twimg.com/profile_images/818997879696195584/1_vmf7bc_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/818997879696195584/1_vmf7bc_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Mina Markham" />
 Mina Markham  
 Topics: CSS Architecture, Sass, Community, Design Systems  
 https://twitter.com/MinaMarkham
 
-<img src="https://pbs.twimg.com/profile_images/779808817785675776/Hf9AwdFs_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/779808817785675776/Hf9AwdFs_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Monica Dinculescu" />
 Monica Dinculescu  
 Topics: Web Components, Polymer, Emoji  
 https://twitter.com/notwaldorf
 
-<img src="https://pbs.twimg.com/profile_images/865264595195265024/EuTAyJFJ_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/865264595195265024/EuTAyJFJ_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Preethi Kasireddy" />
 Preethi Kasireddy  
 Topics: Machine Learning, Natural Language Processing, React  
 https://twitter.com/iam_preethi
 
-<img src="https://pbs.twimg.com/profile_images/856249108885110784/97cssCek_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/856249108885110784/97cssCek_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sarah Drasner" />
 Sarah Drasner  
 Topics: CSS, SVG, Animations, Vue.js, React  
 https://twitter.com/sarah_edo
 
-<img src="https://pbs.twimg.com/profile_images/913444398133735427/7zjUK6pp_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/913444398133735427/7zjUK6pp_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Sean Grove" />
 Sean Grove  
 Topics: GraphQL, ReasonML, OCaml  
 https://twitter.com/sgrove
 
-<img src="https://pbs.twimg.com/profile_images/847556940028923905/xlh3pLCr_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/847556940028923905/xlh3pLCr_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Stephanie Rewis" />
 Stephanie Rewis  
 Topics: Design Systems, CSS  
 https://twitter.com/stefsull
 
-<img src="https://pbs.twimg.com/profile_images/821783522427834369/SOIW4xGP_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/821783522427834369/SOIW4xGP_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Tracy Lee" />
 Tracy Lee  
 Topics: Reactive Programming, Angular, Ember.js  
 https://twitter.com/ladyleet
@@ -1012,7 +1008,7 @@ https://twitter.com/ladyleet
 
 ### Buenos Aires
 
-<img src="https://pbs.twimg.com/profile_images/540127281490845697/_2zxxUOt_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/540127281490845697/_2zxxUOt_400x400.jpeg" height="70px" width="auto" align="left" alt="Headshot of Evangelina Ferreira" />
 Evangelina Ferreira   
 Topics: CSS, Animations   
 https://twitter.com/evaferreira92
@@ -1021,14 +1017,14 @@ https://twitter.com/evaferreira92
 
 ### Belo Horizonte
 
-<img src="https://pbs.twimg.com/profile_images/880632277188972544/iHbGo43-_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/880632277188972544/iHbGo43-_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Beto Muniz" />
 Beto Muniz  
 Topics: React, JavaScript, PWA, Polymer, Community  
 https://twitter.com/obetomuniz
 
 ### Curitiba
 
-<img src="https://pbs.twimg.com/profile_images/824222313470169088/Te_e1i1f_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/824222313470169088/Te_e1i1f_400x400.jpg" height="70px" width="auto" align="left" alt="Headshot of Fernando Daciuk" />
 Fernando Daciuk  
 Topics: React, JavaScript  
 https://twitter.com/fdaciuk

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 Hi, I'm Karl and I'd like to help make it more transparent and easy to find speakers for meetups and conferences. Below I've started to compile a list of speakers that I'm aware of and the topics that they have spoken about (in parentheses are future topics of interest to the speaker).
 
 Please add to the list and help make the community better connected and richer.
-# Africa
-## Nigeria 🇳🇬
-<img src="https://pbs.twimg.com/profile_images/911164658047963136/SLtLXQQp_400x400.jpg" height="70px" width="auto" align="left" />  
 
+# Africa
+
+## Nigeria 🇳🇬
+<img src="https://pbs.twimg.com/profile_images/911164658047963136/SLtLXQQp_400x400.jpg" height="70px" width="auto" align="left" />
 Ire Aderinokun  
 Topics: PWA, CSS, Standards  
 https://twitter.com/ireaderinokun   
@@ -20,8 +21,7 @@ https://twitter.com/ireaderinokun
 
 ### Bangalore
 
-<img src="https://avatars3.githubusercontent.com/u/1382793?s=460&v=4" height="70px" width="auto" align="left" />  
-
+<img src="https://avatars3.githubusercontent.com/u/1382793?s=460&v=4" height="70px" width="auto" align="left" />
 Ashrith Kulai  
 Topics: PWA, Polymer, Web Components, Web Performance, Build Tools  
 https://twitter.com/ashrith_kulai  
@@ -671,8 +671,7 @@ Bodil Stokke
 Topics: Programming, Functional Programming  
 https://twitter.com/bodil
 
-<img src="https://pbs.twimg.com/profile_images/780901614794178560/XcFiEOAH_400x400.jpg" height="70px" width="auto" align="left" />  
-
+<img src="https://pbs.twimg.com/profile_images/780901614794178560/XcFiEOAH_400x400.jpg" height="70px" width="auto" align="left" />
 Chris Noring  
 Topics: JS, RXJS, Angular, React  
 https://twitter.com/chris_noring  
@@ -712,14 +711,12 @@ Phil Plückthun
 Topics: React, CSS in JS  
 https://twitter.com/_philpl
 
-<img src="https://pbs.twimg.com/profile_images/848590650349989888/6-cAgkjO_400x400.jpg" height="70px" width="auto" align="left" />  
-
+<img src="https://pbs.twimg.com/profile_images/848590650349989888/6-cAgkjO_400x400.jpg" height="70px" width="auto" align="left" />
 Sani Yusuf  
 Topics: Ionic, Angular, JS, PWA  
 https://twitter.com/saniyusuf  
 
-<img src="https://pbs.twimg.com/profile_images/752636760245534720/aWQ8XKJD_400x400.jpg" height="70px" width="auto" align="left" />  
-
+<img src="https://pbs.twimg.com/profile_images/752636760245534720/aWQ8XKJD_400x400.jpg" height="70px" width="auto" align="left" />
 Sebastian Witalec  
 Topics: NativeScript, Angular, BOTS, JS  
 https://twitter.com/sebawita  


### PR DESCRIPTION
As Léonie Watson pointed out, all the <img> tags are missing the alt text (see https://github.com/karlhorky/awesome-speakers/pull/71#issuecomment-343608435). 
I have added it for all the speakers in the list and unified as much as possible the spaces.

please @SaraVieira @karlhorky can you pull this change as soon as possible to avoid too many conflicts?