### PR TITLE
Add empty alt text to skip image in screen readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Hi, I'm Karl and I'd like to help make it more transparent and easy to find spea
 Please add to the list and help make the community better connected and richer.
 # Africa
 ## Nigeria 🇳🇬
-<img src="https://pbs.twimg.com/profile_images/911164658047963136/SLtLXQQp_400x400.jpg" height="70px" width="auto" align="left" />  
+<img src="https://pbs.twimg.com/profile_images/911164658047963136/SLtLXQQp_400x400.jpg" height="70px" width="auto" align="left" alt="" />  
 
 Ire Aderinokun  
 Topics: PWA, CSS, Standards  
@@ -20,19 +20,19 @@ https://twitter.com/ireaderinokun
 
 ### Bangalore
 
-<img src="https://avatars3.githubusercontent.com/u/1382793?s=460&v=4" height="70px" width="auto" align="left" />  
+<img src="https://avatars3.githubusercontent.com/u/1382793?s=460&v=4" height="70px" width="auto" align="left" alt="" />  
 
 Ashrith Kulai  
 Topics: PWA, Polymer, Web Components, Web Performance, Build Tools  
 https://twitter.com/ashrith_kulai  
 
-<img src="https://i.imgur.com/OXCWwy7.jpg" height="70px" width="auto" align="left" />
+<img src="https://i.imgur.com/OXCWwy7.jpg" height="70px" width="auto" align="left" alt="" />
 
 Kumar Anirudha  
 Topics: Python, Node.js, Blockchain, Architecture, Cryptocurrency  
 https://twitter.com/kranirudha
 
-<img src="https://pbs.twimg.com/profile_images/895583823202668544/kFsLGKC3_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/895583823202668544/kFsLGKC3_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Siddharth Kshetrapal  
 Topics: CSS, Web Performance, React, CSS in JS, Node, Testing  
@@ -40,19 +40,19 @@ https://twitter.com/siddharthkp
 
 ### Mumbai
 
-<img src="https://pbs.twimg.com/profile_images/856209876732739585/rQcsMvCa_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/856209876732739585/rQcsMvCa_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Manjula Dube  
 Topics: JavaScript, React, PWA, Node, Testing  
 https://twitter.com/manjula_dube
 
-<img src="https://pbs.twimg.com/profile_images/890131426217259008/6LEkT3eS_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/890131426217259008/6LEkT3eS_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Neehar Venugopal  
 Topics: Code Splitting, Standards  
 https://twitter.com/neeharv
 
-<img src="https://pbs.twimg.com/profile_images/907656585752842250/PwI99gBG_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/907656585752842250/PwI99gBG_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Sidhartha Chatterjee  
 Topics: React, PWA, Web Performance  
@@ -60,7 +60,7 @@ https://twitter.com/chatsidhartha
 
 ### New Delhi
 
-<img src="https://pbs.twimg.com/profile_images/514383461583294464/bIXQJcyG_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/514383461583294464/bIXQJcyG_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Arun Michael Dsouza  
 Topics: webpack, React, ES6, Tooling, CSS  
@@ -70,7 +70,7 @@ https://twitter.com/amdsouza92
 
 ### Tyre
 
-<img src="https://pbs.twimg.com/profile_images/903537944320987136/wB28L8qd_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/903537944320987136/wB28L8qd_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Sara Soueidan  
 Topics: Animations, CSS, SVG  
@@ -80,19 +80,19 @@ https://twitter.com/sarasoueidan
 
 ### Singapore
 
-<img src="https://pbs.twimg.com/profile_images/535685345472286720/9gjiNZiF_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/535685345472286720/9gjiNZiF_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Aysha Anggraini  
 Topics: CSS, Animations  
 https://twitter.com/renettarenula
 
-<img src="https://pbs.twimg.com/profile_images/917359648524558336/Zu2sC6Jk_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/917359648524558336/Zu2sC6Jk_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Chen Hui Jing  
 Topics: CSS  
 https://twitter.com/hj_chen
 
-<img src="https://pbs.twimg.com/profile_images/791843247312154625/UsLdWIIj_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/791843247312154625/UsLdWIIj_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Zell Liew  
 Topics: CSS, JavaScript  
@@ -104,25 +104,25 @@ https://twitter.com/zellwk
 
 ### Melbourne
 
-<img src="https://pbs.twimg.com/profile_images/683874690293612545/kDStZOBp_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/683874690293612545/kDStZOBp_400x400.png" height="70px" width="auto" align="left" alt="" />
 
 Glen Maddern  
 Topics: CSS, Styled Components, React, JavaScript  
 https://twitter.com/glenmaddern
 
-<img src="https://pbs.twimg.com/profile_images/898083700818169856/prj-so7C_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/898083700818169856/prj-so7C_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Karolina Szczur  
 Topics: CSS, HTML, Web, Inclusivity, Diversity  
 https://twitter.com/fox
 
-<img src="https://pbs.twimg.com/profile_images/754886061872979968/BzaOWhs1_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/754886061872979968/BzaOWhs1_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Mark Dalgleish  
 Topics: Design Systems, Web Design  
 https://twitter.com/markdalgleish
 
-<img src="https://pbs.twimg.com/profile_images/789522857936220160/6OIm0gj0_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/789522857936220160/6OIm0gj0_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Phil Nash  
 Topics: JavaScript, Web Development, Progressive Web Apps  
@@ -134,7 +134,7 @@ https://twitter.com/philnash
 
 ### Linz
 
-<img src="https://pbs.twimg.com/profile_images/572642811029426177/GxgFcPtm_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/572642811029426177/GxgFcPtm_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Stefan Baumgartner  
 Topics: Web Ops, JavaScript, CSS, Tooling  
@@ -142,7 +142,7 @@ https://twitter.com/ddprrt
 
 ### Salzburg
 
-<img src="https://pbs.twimg.com/profile_images/861132772366331905/4xts32Lq_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/861132772366331905/4xts32Lq_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Lisi Linhart  
 Topics: CSS, Web Animations  
@@ -150,91 +150,91 @@ https://twitter.com/lisi_linhart
 
 ### Vienna
 
-<img src="https://pbs.twimg.com/profile_images/1492139238/profile_pic.jpg_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/1492139238/profile_pic.jpg_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Ali Sharif  
 Topics: Functional Programming, Agile, Product Development  
 https://twitter.com/sharifsbeat
 
-<img src="https://pbs.twimg.com/profile_images/678903331176214528/TQTdqGwD_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/678903331176214528/TQTdqGwD_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Andrey Okonetchnikov  
 Topics: CSS in JS, Linting, Tooling  
 https://twitter.com/okonetchnikov
 
-<img src="https://pbs.twimg.com/profile_images/831514456828026880/IeSbt2Nw_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/831514456828026880/IeSbt2Nw_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Christoph Rumpel  
 Topics: PHP, Laravel, Chatbots  
 https://twitter.com/christophrumpel
 
-<img src="https://pbs.twimg.com/profile_images/708910026245738496/CUhZSMYO_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/708910026245738496/CUhZSMYO_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Eva Lettner  
 Topics: CSS, Web  
 https://twitter.com/eva_trostlos
 
-<img src="https://pbs.twimg.com/profile_images/687205014348103680/ZcIXYv4g_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/687205014348103680/ZcIXYv4g_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Glenn Reyes  
 Topics: Code splitting, React  
 https://twitter.com/glnnrys
 
-<img src="https://pbs.twimg.com/profile_images/875719105839603712/_nJ_XRw1_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/875719105839603712/_nJ_XRw1_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Jan Hruby  
 Topics: React, Redux, CSS in JS, (React Native, Serverless, GraphQL)  
 https://twitter.com/mrozilla  
 
-<img src="https://pbs.twimg.com/profile_images/883661923107180544/OpPpk-Ku_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/883661923107180544/OpPpk-Ku_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Juho Vepsäläinen  
 Topics: 3D graphics, Business, React, webpack, Writing  
 https://twitter.com/bebraw
 
-<img alt="Manuel Matuzović" src="https://pbs.twimg.com/profile_images/707504523678523392/Uasvv2C4_400x400.jpg" height="70" align="left">  
+<img alt="Manuel Matuzović" src="https://pbs.twimg.com/profile_images/707504523678523392/Uasvv2C4_400x400.jpg" height="70" align="left" alt="">  
 
 Manuel Matuzović  
 Topics: CSS, Accesibility  
 https://twitter.com/mmatuzo  
 
-<img src="https://pbs.twimg.com/profile_images/827473632351879169/ZnoB7yTR_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/827473632351879169/ZnoB7yTR_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Max Böck  
 Topics: CSS, JavaScript, Progressive Web Apps  
 https://twitter.com/mxbck
 
-<img src="https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/763033229993574400/6frGyDyA_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Max Stoiber  
 Topics: React, Styled Components, OSS  
 https://twitter.com/mxstbr
 
-<img src="https://pbs.twimg.com/profile_images/814140031237496832/G-OShJRF_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/814140031237496832/G-OShJRF_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Nik Graf  
 Topics: VR, Serverless, React  
 https://twitter.com/nikgraf
 
-<img src="https://pbs.twimg.com/profile_images/506474262278856704/V9E39edd_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/506474262278856704/V9E39edd_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Oliver Schöndorfer  
 Topics: Typography, CSS   
 https://twitter.com/glyphe
 
-<img src="https://pbs.twimg.com/profile_images/923184283367469057/HFTSuBcW_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/923184283367469057/HFTSuBcW_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Patrick Stapfer  
 Topics: ReasonML, Static Typing, Flow  
 https://twitter.com/ryyppy
 
-<img src="https://pbs.twimg.com/profile_images/868930803425828864/1TWl571x_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/868930803425828864/1TWl571x_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Peter Ferak  
 Topics: Functional Programming, Computer Science  
 https://twitter.com/ferakpeter
 
-<img src="https://pbs.twimg.com/profile_images/881236730254434304/JZs8wBHX_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/881236730254434304/JZs8wBHX_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Timo Obereder  
 Topics: React, Composition, Android, RXJava, Kotlin  
@@ -244,7 +244,7 @@ https://twitter.com/defuex
 
 ### Hasselt
 
-<img src="https://pbs.twimg.com/profile_images/785464929948172288/SV_c8q7S_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/785464929948172288/SV_c8q7S_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Sam Bellen  
 Topics: Web Audio, Browser APIs  
@@ -254,7 +254,7 @@ https://twitter.com/sambego
 
 ### Sofia
 
-<img src="https://pbs.twimg.com/profile_images/1267189835/rado_color_180_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/1267189835/rado_color_180_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Radoslav Stankov  
 Topics: React, Redux, Ruby, Testing, GraphQL  
@@ -264,19 +264,19 @@ https://twitter.com/rstankov
 
 ### Copenhagen
 
-<img src="https://pbs.twimg.com/profile_images/907970058625875968/7ecTxUP4_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/907970058625875968/7ecTxUP4_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Mathias Buus  
 Topics: Peer to Peer, Node.js  
 https://twitter.com/mafintosh
 
-<img src="https://pbs.twimg.com/profile_images/783752447940497408/R8S23hzW_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/783752447940497408/R8S23hzW_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Olga Dmitricenko  
 Topics: VR, Web Image Processing  
 https://twitter.com/enthusiasto
 
-<img src="https://pbs.twimg.com/profile_images/824242201655910400/mY7NMaDE_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/824242201655910400/mY7NMaDE_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Tereza Sokol  
 Topics: Elm, Visualizations  
@@ -286,7 +286,7 @@ https://twitter.com/terezk_a
 
 ### Helsinki
 
-<img src="https://pbs.twimg.com/profile_images/914150533820243970/DnBSM3RF_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/914150533820243970/DnBSM3RF_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Varya Stepanova  
 Topics: CSS in JS, Style Guides, Visual Regression Testing  
@@ -296,7 +296,7 @@ https://twitter.com/varya_en
 
 ### Strasbourg
 
-<img src="https://pbs.twimg.com/profile_images/805046964077400064/TYMf6IWP_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/805046964077400064/TYMf6IWP_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Sven Sauleau    
 Topics: JavaScript (Babel), Artificial Intelligence, Linux, Cloud, Ops, Computer Science    
@@ -306,7 +306,7 @@ https://twitter.com/svensauleau
 
 ### Augsburg
 
-<img src="https://pbs.twimg.com/profile_images/715935523630669824/GJ1Xyp_s_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/715935523630669824/GJ1Xyp_s_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Johannes Ewald  
 Topics: Tooling, Standards, webpack  
@@ -314,61 +314,61 @@ https://twitter.com/Jhnnns
 
 ### Berlin
 
-<img src="https://pbs.twimg.com/profile_images/608674513241427968/ycianjI2_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/608674513241427968/ycianjI2_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Ally Long  
 Topics: CSS, Performance,  
 https://twitter.com/allyelle
 
-<img src="https://pbs.twimg.com/profile_images/770970370409201664/NtuKnExn_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/770970370409201664/NtuKnExn_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Artem Sapegin  
 Topics: Styleguides, UI, CSS  
 https://twitter.com/iamsapegin
 
-<img src="https://pbs.twimg.com/profile_images/894641577557192704/ghN7wHa-_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/894641577557192704/ghN7wHa-_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Charlie Owen  
 Topics: CSS, Accessibility  
 https://twitter.com/sonniesedge
 
-<img src="https://pbs.twimg.com/profile_images/881401440098557952/HZzFErcN_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/881401440098557952/HZzFErcN_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Hernán Magrini  
 Topics: Web Performance, Service Workers  
 https://twitter.com/hermagrini
 
-<img src="https://pbs.twimg.com/profile_images/858703912769081345/edLyRpPr_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/858703912769081345/edLyRpPr_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Karl Horky  
 Topics: Tooling, Standards, (OSS), (Psychology)  
 https://twitter.com/karlhorky
 
-<img src="https://pbs.twimg.com/profile_images/908054663483838464/KFIQs9d3_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/908054663483838464/KFIQs9d3_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Lu Yu  
 Topics: Graphic Design, Typography, Branding, User Experience  
 https://twitter.com/Lugotype
 
-<img src="https://pbs.twimg.com/profile_images/2687722789/0146561e2d575b3e7104e7e94be62b1c_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/2687722789/0146561e2d575b3e7104e7e94be62b1c_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Natalie Pistunovich  
 Topics: Mobile Apps, Go  
 https://twitter.com/nataliepis
 
-<img src="https://pbs.twimg.com/profile_images/754012456368963586/DOwDLy2k_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/754012456368963586/DOwDLy2k_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Oleg Slobodskoi  
 Topics: CSS in JS, React  
 https://twitter.com/oleg008
 
-<img src="https://pbs.twimg.com/profile_images/892332104012484608/_3R1X9CN_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/892332104012484608/_3R1X9CN_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Robin Pokorny  
 Topics: Jest, React, AMP, (Elm)  
 https://twitter.com/robinpokorny
 
-<img src="https://pbs.twimg.com/profile_images/889222391007719424/VZb5oY8a_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/889222391007719424/VZb5oY8a_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Yoshua Wuyts  
 Topics: Frameworks, Simplicity, Standards, Libraries  
@@ -376,7 +376,7 @@ https://twitter.com/yoshuawuyts
 
 ### Düsseldorf
 
-<img src="https://pbs.twimg.com/profile_images/768792268983701504/kIRa8QWM_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/768792268983701504/kIRa8QWM_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Joy Clark  
 Topics: Clojure, Web Apps, Security  
@@ -384,7 +384,7 @@ https://twitter.com/iamjoyclark
 
 ### Freiburg
 
-<img src="https://2016.jsconf.is/71c6f10e201cfb70e77c61a513d62729.jpg" height="70px" width="auto" align="left" />
+<img src="https://2016.jsconf.is/71c6f10e201cfb70e77c61a513d62729.jpg" height="70px" width="auto" align="left" alt="" />
 
 Vitaly Friedman  
 Topics: Web Design, Web Development, Responsive Web Design  
@@ -392,13 +392,13 @@ https://twitter.com/smashingmag
 
 ### Hamburg
 
-<img src="https://pbs.twimg.com/profile_images/2127157281/Martin_Kleppe_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/2127157281/Martin_Kleppe_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Martin Kleppe  
 Topics: Weird JS  
 https://twitter.com/aemkei
 
-<img src="https://pbs.twimg.com/profile_images/530780279162429440/AeXURjRd_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/530780279162429440/AeXURjRd_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Mauricio Palma  
 Topics: CSS, JavaScript  
@@ -406,7 +406,7 @@ https://twitter.com/PalmaSwell
 
 ### Karlsruhe
 
-<img src="https://pbs.twimg.com/profile_images/925825609439301633/8lVHsfdV_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/925825609439301633/8lVHsfdV_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Robin Frischmann  
 Topics: CSS, CSS in JS, React  
@@ -414,13 +414,13 @@ https://twitter.com/rofrischmann
 
 ### Munich
 
-<img src="https://pbs.twimg.com/profile_images/661485440751509505/ZnNN9qes_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/661485440751509505/ZnNN9qes_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Franziska Hinkelmann  
 Topics: Node, V8  
 https://twitter.com/fhinkel
 
-<img src="https://pbs.twimg.com/profile_images/1255767431/kung-fu_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/1255767431/kung-fu_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Mathias Bynens  
 Topics: JavaScript (TC39), V8, Chrome  
@@ -430,13 +430,13 @@ https://twitter.com/mathias
 
 ### Dublin
 
-<img src="https://pbs.twimg.com/profile_images/775076695049113600/fTuBJGTA_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/775076695049113600/fTuBJGTA_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Ingrid Epure  
 Topics: Security, Psychology  
 https://twitter.com/ingridepure
 
-<img src="https://s.gravatar.com/avatar/55066ecb49b57ff9531581b8343aa4fa?size=140" height="70px" width="auto" align="left" />
+<img src="https://s.gravatar.com/avatar/55066ecb49b57ff9531581b8343aa4fa?size=140" height="70px" width="auto" align="left" alt="" />
 
 Serena Fritsch  
 Topics: JavaScript, Ember, Developer Workflows  
@@ -444,19 +444,19 @@ https://twitter.com/serifritsch
 
 ## Israel 🇮🇱
 
-<img src="https://pbs.twimg.com/profile_images/736999006220455938/oczRgifS_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/736999006220455938/oczRgifS_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Nir Galon  
 Topics: Python, API Star, Open Source, Node.js, Angular  
 https://twitter.com/nirgn975
 
-<img src="https://pbs.twimg.com/profile_images/846618003085111296/mi84SWuu_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/846618003085111296/mi84SWuu_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Nir Kaufman  
 Topics: Angular, Firebase, Redux  
 https://twitter.com/nirkaufman
 
-<img src="https://pbs.twimg.com/profile_images/668125552474062848/pTCvcmC3_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/668125552474062848/pTCvcmC3_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Uri Shaked  
 Topics: Web Bluetooth, Web VR, Angular, Internet of Things with JavaScript  
@@ -466,7 +466,7 @@ https://twitter.com/UriShaked
 
 ### Milan
 
-<img src="https://pbs.twimg.com/profile_images/845799912222674945/70ofyabn_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/845799912222674945/70ofyabn_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Maurizio Mangione  
 Topics: Web Components, Polymer, Progressive Web Apps  
@@ -474,7 +474,7 @@ https://twitter.com/granze
 
 ## Verona
 
-<img src="https://pbs.twimg.com/profile_images/873084382235418625/qckzbrGr_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/873084382235418625/qckzbrGr_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Matteo Ronchi  
 Topics: React, JavaScript, Flow, Web Architectures, Frontend Ops  
@@ -484,31 +484,31 @@ https://twitter.com/cef62
 
 ### Amsterdam
 
-<img src="https://pbs.twimg.com/profile_images/905763629701660674/u7wBGyAa_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/905763629701660674/u7wBGyAa_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Alexey Kureev  
 Topics: React Native  
 https://twitter.com/kureevalexey
 
-<img src="https://pbs.twimg.com/profile_images/734378184918073348/j3bsV9Xk_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/734378184918073348/j3bsV9Xk_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Carmen Popoviciu  
 Topics: Angular, JavaScript, Machine Learning, Neural Networks, Polymer, Web Components  
 https://twitter.com/carmenpopoviciu
 
-<img src="https://pbs.twimg.com/profile_images/852804703373074432/YVMyqpMW_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/852804703373074432/YVMyqpMW_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Kitze  
 Topics: MobX, State Management, GraphQL, CSS in JS  
 https://twitter.com/thekitze
 
-<img src="https://pbs.twimg.com/profile_images/661253444058005504/uO5nbrTL_bigger.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/661253444058005504/uO5nbrTL_bigger.jpg" height="70px" width="auto" align="left" alt="" />
 
 Michel Weststrate  
 Topics: MobX, React, mobx-state-tree, Typescript, Open Source  
 https://twitter.com/mweststrate
 
-<img src="https://pbs.twimg.com/profile_images/859482903763460098/565FGTxs_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/859482903763460098/565FGTxs_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Narendra Shetty  
 Topics: React, PWA  
@@ -516,7 +516,7 @@ https://twitter.com/narendra_shetty
 
 ### Zwolle
 
-<img src="https://pbs.twimg.com/profile_images/722165598579507205/l4QzAmu8_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/722165598579507205/l4QzAmu8_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Norbert de Langen  
 Topics: Component Libraries, React, Storybook, Open Source, Communities  
@@ -526,7 +526,7 @@ https://twitter.com/NorbertdeLangen
 
 ### Gdańsk
 
-<img src="https://pbs.twimg.com/profile_images/910825228175069184/WC_iMm7-_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/910825228175069184/WC_iMm7-_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Kasia Jastrzębska  
 Topics: React, Redux, Async, CSS in JS, ClojureScript  
@@ -534,7 +534,7 @@ https://twitter.com/kejt_bw
 
 ### Krakow
 
-<img src="https://pbs.twimg.com/profile_images/378800000409145857/2224a7110f583fb0661ca7cfdf01ce76_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/378800000409145857/2224a7110f583fb0661ca7cfdf01ce76_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Anna Migas  
 Topics: HTML, CSS, JavaScript, Web Animations, Web Performance  
@@ -542,7 +542,7 @@ https://twitter.com/szynszyliszys
 
 ### Poznań
 
-<img src="https://pbs.twimg.com/profile_images/858080114197880833/DXeDmf51_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/858080114197880833/DXeDmf51_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Tomasz Łakomy  
 Topics: React, VR, jQuery  
@@ -550,7 +550,7 @@ https://twitter.com/tlakomy
 
 ### Warsaw
 
-<img src="https://pbs.twimg.com/profile_images/889850940852973568/kqTZlAf5_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/889850940852973568/kqTZlAf5_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Aga Naplocha  
 Topics: CSS, Teaching Web Technologies  
@@ -558,7 +558,7 @@ https://twitter.com/aganaplocha
 
 ### Wrocław
 
-<img src="https://pbs.twimg.com/profile_images/910449258263916545/l0pbXflE_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/910449258263916545/l0pbXflE_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Mike Grabowski  
 Topics: React Native, JavaScript, Tooling  
@@ -568,13 +568,13 @@ https://twitter.com/grabbou
 
 ### Lisbon
 
-<img src="https://pbs.twimg.com/profile_images/841594344658391043/xh_QO-C9_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/841594344658391043/xh_QO-C9_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Daniela Matos de Carvalho  
 Topics: HTTP/2, JavaScript, React, Offline First  
 https://twitter.com/sericaia
 
-<img src="https://pbs.twimg.com/profile_images/849780545823195136/afw55D2y_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/849780545823195136/afw55D2y_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 David Dias  
 Topics: IPFS, P2P, JavaScript, Node.js  
@@ -582,7 +582,7 @@ https://twitter.com/daviddias
 
 ### Porto
 
-<img src="https://pbs.twimg.com/profile_images/926881997863211008/WMzMYyCe_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/926881997863211008/WMzMYyCe_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Sara Vieira  
 Topics: Styleguides, React, CSS  
@@ -592,19 +592,19 @@ https://twitter.com/NikkitaFTW
 
 ### Moscow
 
-<img src="https://pbs.twimg.com/profile_images/486131556675616770/3695qr5w_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/486131556675616770/3695qr5w_400x400.png" height="70px" width="auto" align="left" alt="" />
 
 Nikita Prokopov  
 Topics: Clojure, DataScript, Rum, FiraCode, AnyBar  
 https://twitter.com/nikitonsky
 
-<img src="https://pbs.twimg.com/profile_images/880419066833510400/xJ1uiJUF_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/880419066833510400/xJ1uiJUF_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Sergey Rubanov  
 Topics: Standards, Web Assembly  
 https://twitter.com/chicoxyzzy
 
-<img src="http://fpconf.ru/images/sobolev.jpg" height="70px" width="auto" align="left" />
+<img src="http://fpconf.ru/images/sobolev.jpg" height="70px" width="auto" align="left" alt="" />
 
 Nikita Sobolev  
 Topics: Elixir, Python  
@@ -614,13 +614,13 @@ https://twitter.com/elixir_lang_mos
 
 ### Belgrade
 
-<img src="https://pbs.twimg.com/profile_images/823894615145201664/0xxSg0_c_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/823894615145201664/0xxSg0_c_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Aleksandar Simovic  
 Topics: Serverless  
 https://twitter.com/simalexan
 
-<img src="https://pbs.twimg.com/profile_images/858708563488845829/bfs-19gk_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/858708563488845829/bfs-19gk_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Slobodan Stojanović  
 Topics: Serverless, Offline Web, Chat Bots  
@@ -630,7 +630,7 @@ Topics: Serverless, Offline Web, Chat Bots
 
 ### Córdoba
 
-<img src="https://pbs.twimg.com/profile_images/916227643913244672/uR9VcF3B_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/916227643913244672/uR9VcF3B_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Javi Velasco  
 Topics: React, CSS in JS, React Toolbox  
@@ -638,7 +638,7 @@ https://twitter.com/javivelasco
 
 ### Santander
 
-<img src="https://pbs.twimg.com/profile_images/1330141226/avatar-500_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/1330141226/avatar-500_400x400.png" height="70px" width="auto" align="left" alt="" />
 
 Erik Rasmussen  
 Topics: React, Redux, Redux-Form, Forms  
@@ -648,13 +648,13 @@ https://twitter.com/erikras
 
 ### Zurich
 
-<img src="https://pbs.twimg.com/profile_images/772017431376175104/XvIsVuB4_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/772017431376175104/XvIsVuB4_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Martin Splitt  
 Topics: VR, Web Performance  
 https://twitter.com/g33konaut
 
-<img src="https://pbs.twimg.com/profile_images/737308641511002113/YB7CH5CE_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/737308641511002113/YB7CH5CE_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Sebastian Siemssen  
 Topics: React, GraphQL, Tooling  
@@ -664,13 +664,13 @@ https://twitter.com/thefubhy
 
 ### Kyiv
 
-<img src="https://pbs.twimg.com/profile_images/918401186516160512/aTJN_ydF_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/918401186516160512/aTJN_ydF_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Gregory Shehet  
 Topics: Functional Reactive Programming, MobX, CSS in JS, React  
 https://twitter.com/AGambit95
 
-<img src="https://pbs.twimg.com/profile_images/908763932747288576/ySuitABV_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/908763932747288576/ySuitABV_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Roman Liutikov  
 Topics: ClojureScript, React, Compilers  
@@ -680,7 +680,7 @@ https://twitter.com/roman01la
 
 ### Birmingham
 
-<img src="https://pbs.twimg.com/profile_images/807277326539046912/EZR6qL-S_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/807277326539046912/EZR6qL-S_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Bruce Lawson  
 Topics: Standards, Performance  
@@ -688,13 +688,13 @@ https://twitter.com/brucel
 
 ### Brighton
 
-<img src="https://pbs.twimg.com/profile_images/727173860764844032/0hGX9DZG_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/727173860764844032/0hGX9DZG_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Jeremy Keith  
 Topics: Standards, Web Development, Web Design, CSS, Accessibility  
 https://twitter.com/adactio
 
-<img src="https://pbs.twimg.com/profile_images/526405732330004483/Cq5RGV8S_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/526405732330004483/Cq5RGV8S_400x400.png" height="70px" width="auto" align="left" alt="" />
 
 Paul Robert Lloyd  
 Topics: Design, Web Design, Architecture, Design Systems, Trains  
@@ -702,13 +702,13 @@ https://twitter.com/paulrobertlloyd
 
 ### Bristol
 
-<img src="https://pbs.twimg.com/profile_images/781380559947915265/wrjtv_jp_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/781380559947915265/wrjtv_jp_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Rachel Andrew  
 Topics: CSS  
 https://twitter.com/rachelandrew
 
-<img src="https://pbs.twimg.com/profile_images/820304800478658562/V20lAtva_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/820304800478658562/V20lAtva_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Ruth John  
 Topics: CSS Animations  
@@ -716,7 +716,7 @@ https://twitter.com/Rumyra
 
 ### Leighton Buzzard
 
-<img src="https://pbs.twimg.com/profile_images/528613343381032960/aFnqmqcK_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/528613343381032960/aFnqmqcK_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Caroline Jarrett  
 Topics: Forms Usability, User Research  
@@ -724,116 +724,116 @@ https://twitter.com/cjforms
 
 ### London
 
-<img src="https://pbs.twimg.com/profile_images/925719098042052610/y-llZ0AF_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/925719098042052610/y-llZ0AF_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Ada Rose Cannon  
 Topics: HTML, CSS, JavaScript, WebVR, Web Technologies, Progressive Web Apps  
 https://twitter.com/lady_ada_king
 
-<img src="https://pbs.twimg.com/profile_images/865146773244858369/YxOo7hIC_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/865146773244858369/YxOo7hIC_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Alessandro Cinelli  
 Topics: JavaScript  
 https://twitter.com/cirpo
 
-<img src="https://pbs.twimg.com/profile_images/1540939151/whereIsAlexWithGlasses_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/1540939151/whereIsAlexWithGlasses_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Alex Lobera  
 Topics: JavaScript, React, Redux, GraphQL  
 https://twitter.com/alex_lobera  
 
-<img src="https://pbs.twimg.com/profile_images/920632138013298689/TdWXZUfN_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/920632138013298689/TdWXZUfN_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Alexandra Deschamps-Sonsino  
 Topics: Internet of Things, Smart Homes, Connected Devices  
 https://twitter.com/iotwatch
 
-<img src="https://pbs.twimg.com/profile_images/518444104854679552/aU3S4Wji_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/518444104854679552/aU3S4Wji_400x400.png" height="70px" width="auto" align="left" alt="" />
 
 Alla Kholmatova  
 Topics: Design Systems  
 https://twitter.com/craftui
 
-<img src="https://pbs.twimg.com/profile_images/923316049050783744/HQTS2EsC_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/923316049050783744/HQTS2EsC_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Andrew Betts  
 Topics: Networks, Performance, Web  
 https://twitter.com/triblondon
 
-<img src="https://pbs.twimg.com/profile_images/829282867020722177/el35E312_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/829282867020722177/el35E312_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Anna Doubková  
 Topics: React, Testing  
 https://twitter.com/lithinn
 
-<img src="https://avatars0.githubusercontent.com/u/17880?s=400&v=4" height="70px" width="auto" align="left" />
+<img src="https://avatars0.githubusercontent.com/u/17880?s=400&v=4" height="70px" width="auto" align="left" alt="" />
 
 Bodil Stokke  
 Topics: Programming, Functional Programming  
 https://twitter.com/bodil
 
-<img src="https://pbs.twimg.com/profile_images/780901614794178560/XcFiEOAH_400x400.jpg" height="70px" width="auto" align="left" />  
+<img src="https://pbs.twimg.com/profile_images/780901614794178560/XcFiEOAH_400x400.jpg" height="70px" width="auto" align="left" alt="" />  
 
 Chris Noring  
 Topics: JS, RXJS, Angular, React  
 https://twitter.com/chris_noring  
 
-<img src="https://pbs.twimg.com/profile_images/818604518820679683/pJd1hqvC_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/818604518820679683/pJd1hqvC_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Cristiano Rastelli  
 Topics: CSS, CSS in JS  
 https://twitter.com/areaweb
 
-<img src="https://pbs.twimg.com/profile_images/906557353549598720/oapgW_Fp_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/906557353549598720/oapgW_Fp_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Dan Abramov  
 Topics: JavaScript, React, Redux, Tooling  
 https://twitter.com/dan_abramov
 
-<img src="https://pbs.twimg.com/profile_images/880760574501679105/i_iXmIbn_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/880760574501679105/i_iXmIbn_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Davide 'Folletto' Casali  
 Topics: Design, User Experience, Management, Leadership, Startup  
 https://twitter.com/Folletto
 
-<img src="https://pbs.twimg.com/profile_images/796861611030024192/pVl1eq7f_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/796861611030024192/pVl1eq7f_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Gerard Sans  
 Topics: Angular, React, GraphQL, CSS Animations, RxJS  
 https://twitter.com/gerardsans
 
-<img src="https://pbs.twimg.com/profile_images/875454858215780352/etiz5li-_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/875454858215780352/etiz5li-_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Gojko Adzic  
 Topics: Testing, Requirements, Serverless  
 https://twitter.com/gojkoadzic
 
-<img src="https://pbs.twimg.com/profile_images/736631175985434624/yYKH74aG_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/736631175985434624/yYKH74aG_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Michele Bertoli  
 Topics: React, Testing  
 https://twitter.com/MicheleBertoli
 
-<img src="https://pbs.twimg.com/profile_images/755148129968787457/iQ16fdT9_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/755148129968787457/iQ16fdT9_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Phil Plückthun  
 Topics: React, CSS in JS  
 https://twitter.com/_philpl
 
-<img src="https://pbs.twimg.com/profile_images/848590650349989888/6-cAgkjO_400x400.jpg" height="70px" width="auto" align="left" />  
+<img src="https://pbs.twimg.com/profile_images/848590650349989888/6-cAgkjO_400x400.jpg" height="70px" width="auto" align="left" alt="" />  
 
 Sani Yusuf  
 Topics: Ionic, Angular, JS, PWA  
 https://twitter.com/saniyusuf  
 
-<img src="https://pbs.twimg.com/profile_images/752636760245534720/aWQ8XKJD_400x400.jpg" height="70px" width="auto" align="left" />  
+<img src="https://pbs.twimg.com/profile_images/752636760245534720/aWQ8XKJD_400x400.jpg" height="70px" width="auto" align="left" alt="" />  
 
 Sebastian Witalec  
 Topics: NativeScript, Angular, BOTS, JS  
 https://twitter.com/sebawita  
 
 
-<img src="https://pbs.twimg.com/profile_images/684731880923639808/4nBLZm9n_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/684731880923639808/4nBLZm9n_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Inayaili de León  
 Topics: Design Systems, Responsive Web Design, Design Leadership, UI  
@@ -841,7 +841,7 @@ https://twitter.com/yaili
 
 ## Norwich
 
-<img src="https://pbs.twimg.com/profile_images/915986359529111552/G2I0qF5G_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/915986359529111552/G2I0qF5G_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Heydon Pickering  
 Topics: Accessibility, Performance, Web  
@@ -853,7 +853,7 @@ https://twitter.com/heydonworks
 
 ### Ottawa
 
-<img src="https://pbs.twimg.com/profile_images/920685564176846848/qI6wBevB_400x400.jpg" height="70px" width="auto" align="left">
+<img src="https://pbs.twimg.com/profile_images/920685564176846848/qI6wBevB_400x400.jpg" height="70px" width="auto" align="left" alt="">
 
 Tanya Janca  
 Topics: InfoSec, Web App Security  
@@ -861,13 +861,13 @@ https://twitter.com/shehackspurple
 
 ### Toronto
 
-<img src="https://pbs.twimg.com/profile_images/912036800960405509/PU-_d_C2_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/912036800960405509/PU-_d_C2_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Brenna O'Brien  
 Topics: Motivation, Psychology, Developer Culture, Public Speaking  
 https://twitter.com/brnnbrn
 
-<img src="https://pbs.twimg.com/profile_images/646718876395311104/VxpVI-O6_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/646718876395311104/VxpVI-O6_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Tiff Nogueira   
 Topics: CSS Grids, React, Redux, Firebase, Flexbox   
@@ -877,13 +877,13 @@ https://twitter.com/tiffcodes
 
 ### Boston
 
-<img src="https://pbs.twimg.com/profile_images/832031365071773696/kDchWPLv_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/832031365071773696/kDchWPLv_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Gleb Bahmutov  
 Topics: Computer Science, JavaScript, Reactive Programming  
 https://twitter.com/bahmutov &bull; https://slides.com/bahmutov &bull; https://glebbahmutov.com/videos
 
-<img src="https://pbs.twimg.com/profile_images/584963092120899586/TxkxQ7Y5_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/584963092120899586/TxkxQ7Y5_400x400.png" height="70px" width="auto" align="left" alt="" />
 
 Lea Verou  
 Topics: CSS, HTML  
@@ -891,7 +891,7 @@ https://twitter.com/leaverou
 
 ### Carlsbad
 
-<img src="https://pbs.twimg.com/profile_images/902276500107362304/vju-WV1i_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/902276500107362304/vju-WV1i_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Michael Jackson  
 Topics: React, JavaScript, React Router  
@@ -899,7 +899,7 @@ https://twitter.com/mjackson
 
 ### Cincinnati
 
-<img src="https://pbs.twimg.com/profile_images/817391213183717376/EtDzr5sO_400x400.jpg" height="70px" width="auto" align="left">
+<img src="https://pbs.twimg.com/profile_images/817391213183717376/EtDzr5sO_400x400.jpg" height="70px" width="auto" align="left" alt="">
 
 Carin Meier  
 Topics: Clojure, Machine Learning, Programming  
@@ -907,7 +907,7 @@ https://twitter.com/gigasquid
 
 ### Denver
 
-<img src="https://pbs.twimg.com/profile_images/923079722778505216/qhL5tFpp_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/923079722778505216/qhL5tFpp_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Miriam Suzanne  
 Topics: CSS, Sass, Architecture, Design Systems  
@@ -915,7 +915,7 @@ https://twitter.com/mirisuzanne
 
 ### Midwest
 
-<img src="https://pbs.twimg.com/profile_images/873189682242367489/ereVA7Ub_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/873189682242367489/ereVA7Ub_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Levi Bostian  
 Topics: Android, RxJava, Kotlin, Freelancing, Swift, iOS, Productivity, Startups, Bootstrapping
@@ -923,7 +923,7 @@ https://twitter.com/levibostian
 
 ### Nashville
 
-<img src="https://pbs.twimg.com/profile_images/899001646679814145/4TU9HfO-_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/899001646679814145/4TU9HfO-_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Aimee Knight  
 Topics: JavaScript, CSS, Angular, Growing Junior Developers  
@@ -931,7 +931,7 @@ https://twitter.com/Aimee_Knight
 
 ### New Jersey
 
-<img src="https://pbs.twimg.com/profile_images/918655507698679808/B8xrPFCs_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/918655507698679808/B8xrPFCs_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Ken Wheeler  
 Topics: React, React Native, ReasonML  
@@ -939,13 +939,13 @@ https://twitter.com/ken_wheeler
 
 ### New Orleans
 
-<img src="https://pbs.twimg.com/profile_images/417667937105752064/Z6SeM2_a_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/417667937105752064/Z6SeM2_a_400x400.png" height="70px" width="auto" align="left" alt="" />
 
 Gant Laborde  
 Topics:  JavaScript, React Native, Leadership, Redux, Open Source, Tooling, Public Speaking  
 https://twitter.com/GantLaborde
 
-<img src="https://pbs.twimg.com/profile_images/861717239002562560/r01NX6n0_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/861717239002562560/r01NX6n0_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Sia Karamalegos  
 Topics: React, JavaScript, React Native, Front-End Performance  
@@ -953,55 +953,55 @@ https://twitter.com/thegreengreek
 
 ### New York
 
-<img src="https://pbs.twimg.com/profile_images/62572418/me_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/62572418/me_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 David Nolen  
 Topics: Clojure, ClojureScript, Om, Functional Programming, Computer Science  
 https://twitter.com/swannodette
 
-<img src="https://pbs.twimg.com/profile_images/412413402749743107/jOnza-Eg_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/412413402749743107/jOnza-Eg_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Diana Mounter  
 Topics: Design Systems, CSS, Product Design  
 https://twitter.com/broccolini
 
-<img src="https://pbs.twimg.com/profile_images/432754023385403393/6lc-7Xqg_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/432754023385403393/6lc-7Xqg_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Henry Zhu  
 Topics: Open Source, Babel  
 https://twitter.com/left_pad
 
-<img src="https://pbs.twimg.com/profile_images/765902179660161024/zCC2yj_R_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/765902179660161024/zCC2yj_R_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Jen Simmons  
 Topics: CSS, HTML, Web  
 https://twitter.com/jensimmons
 
-<img src="https://pbs.twimg.com/profile_images/849322587909967874/pOMAg5VX_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/849322587909967874/pOMAg5VX_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Lara Hogan  
 Topics: Design, Performance, Engineering Management, Public Speaking  
 https://twitter.com/lara_hogan
 
-<img src="https://pbs.twimg.com/profile_images/896883376954757120/gXtYevrr_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/896883376954757120/gXtYevrr_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Kurtis Kemple  
 Topics: React, React Native, GraphQL, Universal Components  
 https://twitter.com/kurtiskemple
 
-<img src="https://pbs.twimg.com/profile_images/593793041816629248/yKbOT56n_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/593793041816629248/yKbOT56n_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Mariko Kosaka  
 Topics: HTML, CSS, JavaScript, Web  
 https://twitter.com/kosamari
 
-<img src="https://pbs.twimg.com/profile_images/783341508820893696/JphRM0xk_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/783341508820893696/JphRM0xk_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Peggy Rayzis  
 Topics: React, React Native, GraphQL  
 https://twitter.com/peggyrayzis
 
-<img src="https://pbs.twimg.com/profile_images/923332236799291393/JFc4MauF_400x400.jpg" height="70px" width="auto" align="left">
+<img src="https://pbs.twimg.com/profile_images/923332236799291393/JFc4MauF_400x400.jpg" height="70px" width="auto" align="left" alt="">
 
 Una Kravets  
 Topics: CSS, Web  
@@ -1009,13 +1009,13 @@ https://twitter.com/una
 
 ### Philadelphia
 
-<img src="https://pbs.twimg.com/profile_images/462071677317160960/fvsOcwr1_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/462071677317160960/fvsOcwr1_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Lis Pardi  
 Topics: Web  
 https://twitter.com/lispardi
 
-<img src="https://pbs.twimg.com/profile_images/635812303342956545/Fo4RyEgH_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/635812303342956545/Fo4RyEgH_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Richard Feldman  
 Topics: Elm  
@@ -1023,13 +1023,13 @@ https://twitter.com/rtfeldman
 
 ### Pittsburgh
 
-<img src="https://pbs.twimg.com/profile_images/907811115459125248/i8AzK6gR_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/907811115459125248/i8AzK6gR_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Brad Frost  
 Topics: Web Design, Atomic Design, Web Development  
 https://twitter.com/brad_frost
 
-<img src="https://pbs.twimg.com/profile_images/497876628651782146/hrCHz_ym_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/497876628651782146/hrCHz_ym_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Lin Clark  
 Topics: React, WebAssembly, Browsers Internals  
@@ -1037,13 +1037,13 @@ https://twitter.com/linclark
 
 ### Portland
 
-<img src="https://pbs.twimg.com/profile_images/786039150667411456/t_0mWTZk_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/786039150667411456/t_0mWTZk_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Kyle Shevlin  
 Topics: React, Redux, JavaScript  
 https://twitter.com/kyleshevlin
 
-<img src="https://pbs.twimg.com/profile_images/684146011564933120/eUohVcRB_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/684146011564933120/eUohVcRB_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Micah Godbolt  
 Topics: Front-End Architecture, CSS, Design Systems  
@@ -1051,7 +1051,7 @@ https://twitter.com/micahgodbolt
 
 ### Salt Lake City
 
-<img src="https://pbs.twimg.com/profile_images/759557613445001216/6M2E1l4q_400x400.jpg" height="70px" width="auto" align="left">
+<img src="https://pbs.twimg.com/profile_images/759557613445001216/6M2E1l4q_400x400.jpg" height="70px" width="auto" align="left" alt="">
 
 Kent C. Dodds  
 Topics: OSS, React, Testing  
@@ -1059,103 +1059,103 @@ https://twitter.com/kentcdodds
 
 ### San Francisco
 
-<img src="https://pbs.twimg.com/profile_images/657238456280731648/YvIabjlq_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/657238456280731648/YvIabjlq_400x400.png" height="70px" width="auto" align="left" alt="" />
 
 Anjana Vakil  
 Topics: Programming Language Paradigms, Functional Programming (with JavaScript)  
 https://twitter.com/AnjanaVakil
 
-<img src="https://pbs.twimg.com/profile_images/745127659340861440/qKoNl3zu_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/745127659340861440/qKoNl3zu_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Beth Dean  
 Topics: Design, Illustration  
 https://twitter.com/bethdean
 
-<img src="https://pbs.twimg.com/profile_images/773213042477637632/Nc8d6VZg_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/773213042477637632/Nc8d6VZg_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Adam Menges  
 Topics: Artificial Intelligence, Design, Computer Science  
 https://twitter.com/adammenges &bull; https://instagram.com/adammenges
 
-<img src="https://pbs.twimg.com/profile_images/880565020173717504/CqM1jdvu_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/880565020173717504/CqM1jdvu_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Boris Cherny  
 Topics: TypeScript, React, Computer Science  
 https://twitter.com/bcherny
 
-<img src="https://pbs.twimg.com/profile_images/451517791091167232/ycYsDdzq_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/451517791091167232/ycYsDdzq_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Brynn Evans  
 Topics: Design, Management  
 https://twitter.com/brynn
 
-<img src="https://pbs.twimg.com/profile_images/744899510/avatar_400x400.png" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/744899510/avatar_400x400.png" height="70px" width="auto" align="left" alt="" />
 
 Estelle Weyl  
 Topics: CSS, Performance, Responsive Web Design  
 https://twitter.com/standardista
 
-<img src="https://pbs.twimg.com/profile_images/491609678539792384/YskBOQeH_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/491609678539792384/YskBOQeH_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Jafar Husain  
 Topics: JavaScript, ES7, Observables, Reactive Programming, Falcor  
 https://twitter.com/jhusain
 
-<img src="https://pbs.twimg.com/profile_images/922512926711332864/qAY-xrsm_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/922512926711332864/qAY-xrsm_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Jon Gold  
 Topics: Design, Design Systems, React, Artificial Intelligence  
 https://twitter.com/jongold
 
-<img src="https://avatars1.githubusercontent.com/u/12424987?s=460&v=4" height="70px" width="auto" align="left" />
+<img src="https://avatars1.githubusercontent.com/u/12424987?s=460&v=4" height="70px" width="auto" align="left" alt="" />
 
 Lisa Huang  
 Topics: AMP, Offline-First Mobile Apps, React  
 https://twitter.com/lisaychuang
 
-<img src="https://pbs.twimg.com/profile_images/767888976166268928/Ieds3b1K_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/767888976166268928/Ieds3b1K_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Mike Matas  
 Topics: Human Interface Design  
 https://twitter.com/mike_matas &bull; https://instagram.com/mike_matas
 
-<img src="https://pbs.twimg.com/profile_images/818997879696195584/1_vmf7bc_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/818997879696195584/1_vmf7bc_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Mina Markham  
 Topics: CSS Architecture, Sass, Community, Design Systems  
 https://twitter.com/MinaMarkham
 
-<img src="https://pbs.twimg.com/profile_images/779808817785675776/Hf9AwdFs_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/779808817785675776/Hf9AwdFs_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Monica Dinculescu  
 Topics: Web Components, Polymer, Emoji  
 https://twitter.com/notwaldorf
 
-<img src="https://pbs.twimg.com/profile_images/865264595195265024/EuTAyJFJ_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/865264595195265024/EuTAyJFJ_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Preethi Kasireddy  
 Topics: Machine Learning, Natural Language Processing, React  
 https://twitter.com/iam_preethi
 
-<img src="https://pbs.twimg.com/profile_images/856249108885110784/97cssCek_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/856249108885110784/97cssCek_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Sarah Drasner  
 Topics: CSS, SVG, Animations, Vue.js, React  
 https://twitter.com/sarah_edo
 
-<img src="https://pbs.twimg.com/profile_images/913444398133735427/7zjUK6pp_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/913444398133735427/7zjUK6pp_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Sean Grove  
 Topics: GraphQL, ReasonML, OCaml  
 https://twitter.com/sgrove
 
-<img src="https://pbs.twimg.com/profile_images/847556940028923905/xlh3pLCr_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/847556940028923905/xlh3pLCr_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Stephanie Rewis  
 Topics: Design Systems, CSS  
 https://twitter.com/stefsull
 
-<img src="https://pbs.twimg.com/profile_images/821783522427834369/SOIW4xGP_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/821783522427834369/SOIW4xGP_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Tracy Lee  
 Topics: Reactive Programming, Angular, Ember.js  
@@ -1167,7 +1167,7 @@ https://twitter.com/ladyleet
 
 ### Buenos Aires
 
-<img src="https://pbs.twimg.com/profile_images/540127281490845697/_2zxxUOt_400x400.jpeg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/540127281490845697/_2zxxUOt_400x400.jpeg" height="70px" width="auto" align="left" alt="" />
 
 Evangelina Ferreira   
 Topics: CSS, Animations   
@@ -1177,7 +1177,7 @@ https://twitter.com/evaferreira92
 
 ### Belo Horizonte 
 
-<img src="https://pbs.twimg.com/profile_images/880632277188972544/iHbGo43-_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/880632277188972544/iHbGo43-_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Beto Muniz  
 Topics: React, JavaScript, PWA, Polymer, Community  
@@ -1185,7 +1185,7 @@ https://twitter.com/obetomuniz
 
 ### Curitiba
 
-<img src="https://pbs.twimg.com/profile_images/824222313470169088/Te_e1i1f_400x400.jpg" height="70px" width="auto" align="left" />
+<img src="https://pbs.twimg.com/profile_images/824222313470169088/Te_e1i1f_400x400.jpg" height="70px" width="auto" align="left" alt="" />
 
 Fernando Daciuk  
 Topics: React, JavaScript  


### PR DESCRIPTION
As mentioned in https://github.com/karlhorky/awesome-speakers/pull/71#issuecomment-343608435

Closes #76 

Why an empty alt attribute? [These reasons](https://github.com/karlhorky/awesome-speakers/pull/76#issuecomment-343661440)